### PR TITLE
Experiment with bootstrap's button dropdown for better styling

### DIFF
--- a/ui/View.elm
+++ b/ui/View.elm
@@ -165,15 +165,17 @@ filterSelector : List String -> String -> String -> (String -> Msg) -> Html Msg
 filterSelector filters filterTitle selectedFilter updateHandler =
     let
         optionView value_ =
-            option [ value value_, selected (value_ == selectedFilter) ] [ text value_ ]
+            li [ onClick <| updateHandler value_ ] [ text value_ ]
 
         selectView =
-            select
-                [ class "form-control"
-                , onInput updateHandler
-                , value selectedFilter
+            div [ class "btn-group input-group" ]
+                [ button [ type_ "button", class "btn btn-default dropdown-toggle", attribute "data-toggle" "dropdown" ]
+                    [ text selectedFilter
+                    , span [ class "caret" ] []
+                    ]
+                , ul [ class "dropdown-menu" ]
+                    (List.map optionView filters)
                 ]
-                (List.map optionView ("all" :: filters))
 
         selectedFilterView =
             div [ class "input-group" ]

--- a/ui/index.html
+++ b/ui/index.html
@@ -6,6 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="//bootswatch.com/slate/bootstrap.min.css" media="all" rel="stylesheet" />
     <link href="style.css" media="all" rel="stylesheet" />
+    <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
   </head>
 
   <body>


### PR DESCRIPTION
This is a very first draft. I'm not that happy about loosing the semantics of the `select` in favor of a plain `button`, and the addition of both jquery and `dropdown.js`. The upside is that the styling is possible, while it's not really with `select`s.

Even though the styling of buttons is easier, it seems i'll have to style them myself (and not use bootstrap's default css) because the result is pretty crappy:

<img width="274" alt="screen shot 2017-05-16 at 14 24 06" src="https://cloud.githubusercontent.com/assets/167767/26105699/5a3890da-3a43-11e7-9ee6-ee06780dd628.png">

So i'm wondering if i should just ditch this PR (and keep the `select`s), or go one step further, and implement the "dropdowns as buttons and ULs" myself (in elm) and style them...

@n1k0 any tips/thoughts?