### PR TITLE
Paginate build list.

### DIFF
--- a/ui/Main.elm
+++ b/ui/Main.elm
@@ -23,6 +23,25 @@ update : Msg -> Model -> ( Model, Cmd Msg )
 update msg ({ filterValues } as model) =
     case msg of
         BuildRecordsFetched (Ok buildsPager) ->
+            updateModelWithFilters
+                { model
+                    | buildsPager = buildsPager
+                    , filteredBuilds = buildsPager.objects
+                    , loading = False
+                }
+                ! []
+
+        BuildRecordsFetched (Err err) ->
+            let
+                _ =
+                    Debug.log "An error occured while fetching the build records" err
+            in
+                model ! []
+
+        LoadNextPage ->
+            model ! [ getNextBuilds model.buildsPager ]
+
+        BuildRecordsNextPageFetched (Ok buildsPager) ->
             let
                 newPager =
                     Kinto.updatePager buildsPager model.buildsPager
@@ -35,15 +54,12 @@ update msg ({ filterValues } as model) =
                     }
                     ! []
 
-        BuildRecordsFetched (Err err) ->
+        BuildRecordsNextPageFetched (Err err) ->
             let
                 _ =
-                    Debug.log "An error occured while fetching the build records" err
+                    Debug.log "An error occured while fetching the next page of build records" err
             in
                 model ! []
-
-        LoadNextPage ->
-            model ! [ getNextBuilds model.buildsPager ]
 
         UpdateFilter newFilter ->
             let

--- a/ui/Main.elm
+++ b/ui/Main.elm
@@ -23,12 +23,10 @@ update : Msg -> Model -> ( Model, Cmd Msg )
 update msg ({ filterValues } as model) =
     case msg of
         BuildRecordsFetched (Ok buildsPager) ->
-            updateModelWithFilters
-                { model
-                    | buildsPager = buildsPager
-                    , filteredBuilds = buildsPager.objects
-                    , loading = False
-                }
+            { model
+                | buildsPager = buildsPager
+                , loading = False
+            }
                 ! []
 
         BuildRecordsFetched (Err err) ->
@@ -46,12 +44,10 @@ update msg ({ filterValues } as model) =
                 newPager =
                     Kinto.updatePager buildsPager model.buildsPager
             in
-                updateModelWithFilters
-                    { model
-                        | buildsPager = newPager
-                        , filteredBuilds = newPager.objects
-                        , loading = False
-                    }
+                { model
+                    | buildsPager = newPager
+                    , loading = False
+                }
                     ! []
 
         BuildRecordsNextPageFetched (Err err) ->
@@ -96,7 +92,7 @@ update msg ({ filterValues } as model) =
                 updatedModelWithRoute =
                     { model | route = routeFromFilters updatedModelWithFilters }
             in
-                updateModelWithFilters updatedModelWithRoute
+                updatedModelWithRoute
                     ! [ newUrl <| urlFromRoute updatedModelWithRoute.route
                       , getBuildRecordList updatedModelWithRoute
                       ]
@@ -104,6 +100,6 @@ update msg ({ filterValues } as model) =
         UrlChange location ->
             let
                 updatedModel =
-                    updateModelWithFilters (routeFromUrl model location)
+                    routeFromUrl model location
             in
                 updatedModel ! [ getBuildRecordList updatedModel ]

--- a/ui/Main.elm
+++ b/ui/Main.elm
@@ -81,7 +81,13 @@ update msg ({ filterValues } as model) =
                     { model | route = routeFromFilters updatedModelWithFilters }
             in
                 updateModelWithFilters updatedModelWithRoute
-                    ! [ newUrl <| urlFromRoute updatedModelWithRoute.route ]
+                    ! [ newUrl <| urlFromRoute updatedModelWithRoute.route
+                      , getBuildRecordList updatedModelWithRoute
+                      ]
 
         UrlChange location ->
-            updateModelWithFilters (routeFromUrl model location) ! []
+            let
+                updatedModel =
+                    updateModelWithFilters (routeFromUrl model location)
+            in
+                updatedModel ! [ getBuildRecordList updatedModel ]

--- a/ui/Model.elm
+++ b/ui/Model.elm
@@ -43,7 +43,7 @@ getBuildRecordList { productFilter, channelFilter, platformFilter, versionFilter
         request =
             client
                 |> Kinto.getList recordResource
-                |> Kinto.limit 10
+                |> Kinto.limit pageSize
                 |> Kinto.sortBy [ "-build.date" ]
 
         filteredRequest =

--- a/ui/Model.elm
+++ b/ui/Model.elm
@@ -79,7 +79,7 @@ getNextBuilds : Kinto.Pager BuildRecord -> Cmd Msg
 getNextBuilds pager =
     case Kinto.loadNextPage pager of
         Just request ->
-            request |> Kinto.send BuildRecordsFetched
+            request |> Kinto.send BuildRecordsNextPageFetched
 
         Nothing ->
             Cmd.none

--- a/ui/Model.elm
+++ b/ui/Model.elm
@@ -30,8 +30,11 @@ init location =
             , loading = True
             , route = MainView
             }
+
+        updatedModel =
+            updateModelWithFilters (routeFromUrl defaultModel location)
     in
-        updateModelWithFilters (routeFromUrl defaultModel location) ! [ getBuildRecordList defaultModel ]
+        updatedModel ! [ getBuildRecordList updatedModel ]
 
 
 getBuildRecordList : Model -> Cmd Msg

--- a/ui/Types.elm
+++ b/ui/Types.elm
@@ -149,5 +149,6 @@ type Route
 type Msg
     = BuildRecordsFetched (Result Kinto.Error (Kinto.Pager BuildRecord))
     | LoadNextPage
+    | BuildRecordsNextPageFetched (Result Kinto.Error (Kinto.Pager BuildRecord))
     | UpdateFilter NewFilter
     | UrlChange Location

--- a/ui/Types.elm
+++ b/ui/Types.elm
@@ -19,7 +19,7 @@ import Navigation exposing (..)
 
 
 type alias Model =
-    { builds : List BuildRecord
+    { buildsPager : Kinto.Pager BuildRecord
     , filteredBuilds : List BuildRecord
     , filterValues : FilterValues
     , productFilter : String
@@ -147,6 +147,7 @@ type Route
 
 
 type Msg
-    = BuildRecordsFetched (Result Kinto.Error (List BuildRecord))
+    = BuildRecordsFetched (Result Kinto.Error (Kinto.Pager BuildRecord))
+    | LoadNextPage
     | UpdateFilter NewFilter
     | UrlChange Location

--- a/ui/Types.elm
+++ b/ui/Types.elm
@@ -1,6 +1,7 @@
 module Types
     exposing
-        ( Build
+        ( pageSize
+        , Build
         , BuildRecord
         , Route(..)
         , Download
@@ -16,6 +17,10 @@ module Types
 
 import Kinto
 import Navigation exposing (..)
+
+
+pageSize =
+    10
 
 
 type alias Model =

--- a/ui/Types.elm
+++ b/ui/Types.elm
@@ -25,7 +25,6 @@ pageSize =
 
 type alias Model =
     { buildsPager : Kinto.Pager BuildRecord
-    , filteredBuilds : List BuildRecord
     , filterValues : FilterValues
     , productFilter : String
     , versionFilter : String

--- a/ui/View.elm
+++ b/ui/View.elm
@@ -36,8 +36,8 @@ mainView model =
         div [ class "row" ]
             [ div [ class "col-sm-9" ]
                 [ numBuilds model
-                , div [] <| List.map recordView model.filteredBuilds
-                , nextPageBtn (List.length model.filteredBuilds) model.buildsPager.total
+                , div [] <| List.map recordView model.buildsPager.objects
+                , nextPageBtn (List.length model.buildsPager.objects) model.buildsPager.total
                 ]
             , div [ class "col-sm-3" ]
                 [ div [ class "panel panel-default" ]
@@ -137,7 +137,7 @@ numBuilds : Model -> Html Msg
 numBuilds model =
     let
         nbBuilds =
-            List.length model.filteredBuilds
+            List.length model.buildsPager.objects
     in
         p [ class "well" ] <|
             [ text <|

--- a/ui/View.elm
+++ b/ui/View.elm
@@ -37,12 +37,7 @@ mainView model =
             [ div [ class "col-sm-9" ]
                 [ numBuilds model
                 , div [] <| List.map recordView model.filteredBuilds
-                , button
-                    [ class "btn btn-default"
-                    , style [ ( "width", "100%" ) ]
-                    , onClick LoadNextPage
-                    ]
-                    [ text "Load more" ]
+                , nextPageBtn (List.length model.filteredBuilds) model.buildsPager.total
                 ]
             , div [ class "col-sm-3" ]
                 [ div [ class "panel panel-default" ]
@@ -430,3 +425,22 @@ onClick_ msg =
         "click"
         { preventDefault = True, stopPropagation = True }
         (Decode.succeed msg)
+
+
+nextPageBtn : Int -> Int -> Html Msg
+nextPageBtn displayed total =
+    if displayed < total then
+        button
+            [ class "btn btn-default"
+            , style [ ( "width", "100%" ) ]
+            , onClick LoadNextPage
+            ]
+            [ text <|
+                "Load "
+                    ++ (toString pageSize)
+                    ++ " more ("
+                    ++ (toString <| total - displayed)
+                    ++ " left)"
+            ]
+    else
+        div [] []

--- a/ui/View.elm
+++ b/ui/View.elm
@@ -153,7 +153,9 @@ numBuilds model =
                         else
                             "s"
                        )
-                    ++ " found. "
+                    ++ " displayed ("
+                    ++ toString model.buildsPager.total
+                    ++ " total)."
             ]
 
 

--- a/ui/View.elm
+++ b/ui/View.elm
@@ -37,6 +37,12 @@ mainView model =
             [ div [ class "col-sm-9" ]
                 [ numBuilds model
                 , div [] <| List.map recordView model.filteredBuilds
+                , button
+                    [ class "btn btn-default"
+                    , style [ ( "width", "100%" ) ]
+                    , onClick LoadNextPage
+                    ]
+                    [ text "Load more" ]
                 ]
             , div [ class "col-sm-3" ]
                 [ div [ class "panel panel-default" ]

--- a/ui/elm-package.json
+++ b/ui/elm-package.json
@@ -8,7 +8,7 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "Kinto/elm-kinto": "3.0.0 <= v < 4.0.0",
+        "Kinto/elm-kinto": "4.0.0 <= v < 5.0.0",
         "NoRedInk/elm-decode-pipeline": "3.0.0 <= v < 4.0.0",
         "basti1302/elm-human-readable-filesize": "1.0.0 <= v < 2.0.0",
         "elm-lang/core": "5.1.1 <= v < 6.0.0",


### PR DESCRIPTION
Note: this is not intended for landing as is. This patch illustrates how the new elm-kinto pagination system works, with a working implementation.

We'll definitely wait for #40 to land first before landing this, especially as this can't fully work with in-memory filtering.