### PR TITLE
Supports Fennec URLs

### DIFF
--- a/jobs/buildhub/utils.py
+++ b/jobs/buildhub/utils.py
@@ -21,22 +21,31 @@ def guess_channel(url, version):
     else:
         if 'b' in version:
             channel = 'beta'
+
+    # Fennec can have different app store ids.
+    if 'old-id' in url:
+        channel += "-old-id"
+
     return channel
 
 
 def build_record_id(record):
     version = record["target"]["version"]
 
-    if record["target"]["channel"] == 'nightly':
+    if 'nightly' in record["target"]["channel"]:
         url_parts = record["download"]["url"].split('/')
         date_parts = url_parts[8].split('-')
         date = '-'.join(date_parts[:6])
         version = '{}_{}'.format(date, version)
 
-    id_ = '{product}_{version}_{platform}_{locale}'.format(product=record["source"]["product"],
-                                                           version=version,
-                                                           platform=record["target"]["platform"],
-                                                           locale=record["target"]["locale"])
+    channel = record["target"]["channel"]
+    channel = channel + "_" if channel != "release" else ""
+    values = dict(product=record["source"]["product"],
+                  channel=channel,
+                  version=version,
+                  platform=record["target"]["platform"],
+                  locale=record["target"]["locale"])
+    id_ = '{product}_{channel}{version}_{platform}_{locale}'.format(**values)
     return id_.replace('.', '-').lower()
 
 

--- a/jobs/setup.py
+++ b/jobs/setup.py
@@ -19,6 +19,7 @@ CONTRIBUTORS = read_file('CONTRIBUTORS.rst')
 REQUIREMENTS = [
     "aiohttp",
     "backoff",
+    "packaging",
     "kinto-http",
     "kinto-wizard",
 ]

--- a/jobs/tests/test_scrape_archives.py
+++ b/jobs/tests/test_scrape_archives.py
@@ -27,7 +27,7 @@ ARCHIVE_INFOS = [
               "date": "2017-05-03T03:02:00",
               "id": "20170503030212"
           },
-          "id": "firefox_2017-05-03-03-02-12_55-0a1_win64_en-us",
+          "id": "firefox_nightly_2017-05-03-03-02-12_55-0a1_win64_en-us",
           "source": {
               "tree": "mozilla-central",
               "repository": "https://hg.mozilla.org/mozilla-central",

--- a/jobs/tests/test_utils.py
+++ b/jobs/tests/test_utils.py
@@ -8,7 +8,7 @@ from buildhub.utils import (
 RECORDS = [
     # Firefox Nightly
     {
-        "id": "firefox_2017-05-15-10-02-38_55-0a1_linux-x86_64_en-us",
+        "id": "firefox_nightly_2017-05-15-10-02-38_55-0a1_linux-x86_64_en-us",
         "source": {
             "product": "firefox",
         },
@@ -26,7 +26,7 @@ RECORDS = [
 
     # Firefox Aurora
     {
-        "id": "firefox_54-0a2_mac_en-us",
+        "id": "firefox_aurora_54-0a2_mac_en-us",
         "source": {
             "product": "firefox",
         },
@@ -44,7 +44,7 @@ RECORDS = [
 
     # Firefox Beta
     {
-        "id": "firefox_52-0b6_linux-x86_64_en-us",
+        "id": "firefox_beta_52-0b6_linux-x86_64_en-us",
         "source": {
             "product": "firefox",
         },
@@ -134,7 +134,7 @@ RECORDS = [
 
     # Fennec
     {
-        "id": "fennec_39-0b5_android-api-9_sl",
+        "id": "fennec_beta_39-0b5_android-api-9_sl",
         "source": {
             "product": "fennec",
         },
@@ -152,7 +152,7 @@ RECORDS = [
 
     # Localized Fennec
     {
-        "id": "fennec_42-0b2_android-api-9_fr",
+        "id": "fennec_beta_42-0b2_android-api-9_fr",
         "source": {
             "product": "fennec",
         },
@@ -171,7 +171,7 @@ RECORDS = [
 
     # Fennec ARM
     {
-        "id": "fennec_2017-05-30-10-01-27_55-0a1_android-api-15_multi",
+        "id": "fennec_nightly_2017-05-30-10-01-27_55-0a1_android-api-15_multi",
         "source": {
             "product": "fennec",
         },
@@ -183,13 +183,29 @@ RECORDS = [
         },
         "download": {
             "url": "https://archive.mozilla.org/pub/mobile/nightly/2017/05/2017-05-30-10-01-27-"
+            "mozilla-central-android-api-15/fennec-55.0a1.multi.android-arm.apk",
+        }
+    },
+    {
+        "id": "fennec_nightly-old-id_2017-05-30-10-01-27_55-0a1_android-api-15_multi",
+        "source": {
+            "product": "fennec",
+        },
+        "target": {
+            "version": "55.0a1",
+            "platform": "android-api-15",
+            "locale": "multi",
+            "channel": "nightly-old-id"
+        },
+        "download": {
+            "url": "https://archive.mozilla.org/pub/mobile/nightly/2017/05/2017-05-30-10-01-27-"
             "mozilla-central-android-api-15-old-id/fennec-55.0a1.multi.android-arm.apk",
         }
     },
 
     # Fennec i386
     {
-        "id": "fennec_2017-05-30-10-01-27_55-0a1_android-i386_multi",
+        "id": "fennec_nightly_2017-05-30-10-01-27_55-0a1_android-i386_multi",
         "source": {
             "product": "fennec",
         },
@@ -198,6 +214,22 @@ RECORDS = [
             "platform": "android-i386",
             "locale": "multi",
             "channel": "nightly"
+        },
+        "download": {
+            "url": "https://archive.mozilla.org/pub/mobile/nightly/2017/05/2017-05-30-10-01-27-"
+            "mozilla-central-android-x86/fennec-55.0a1.multi.android-i386.apk",
+        }
+    },
+    {
+        "id": "fennec_nightly-old-id_2017-05-30-10-01-27_55-0a1_android-i386_multi",
+        "source": {
+            "product": "fennec",
+        },
+        "target": {
+            "version": "55.0a1",
+            "platform": "android-i386",
+            "locale": "multi",
+            "channel": "nightly-old-id"
         },
         "download": {
             "url": "https://archive.mozilla.org/pub/mobile/nightly/2017/05/2017-05-30-10-01-27-"

--- a/jobs/tests/test_utils.py
+++ b/jobs/tests/test_utils.py
@@ -167,6 +167,43 @@ RECORDS = [
             "fennec-42.0b2.fr.android-arm.apk",
         }
     },
+
+
+    # Fennec ARM
+    {
+        "id": "fennec_2017-05-30-10-01-27_55-0a1_android-api-15_multi",
+        "source": {
+            "product": "fennec",
+        },
+        "target": {
+            "version": "55.0a1",
+            "platform": "android-api-15",
+            "locale": "multi",
+            "channel": "nightly"
+        },
+        "download": {
+            "url": "https://archive.mozilla.org/pub/mobile/nightly/2017/05/2017-05-30-10-01-27-"
+            "mozilla-central-android-api-15-old-id/fennec-55.0a1.multi.android-arm.apk",
+        }
+    },
+
+    # Fennec i386
+    {
+        "id": "fennec_2017-05-30-10-01-27_55-0a1_android-i386_multi",
+        "source": {
+            "product": "fennec",
+        },
+        "target": {
+            "version": "55.0a1",
+            "platform": "android-i386",
+            "locale": "multi",
+            "channel": "nightly"
+        },
+        "download": {
+            "url": "https://archive.mozilla.org/pub/mobile/nightly/2017/05/2017-05-30-10-01-27-"
+            "mozilla-central-android-x86-old-id/fennec-55.0a1.multi.android-i386.apk",
+        }
+    },
 ]
 
 
@@ -178,7 +215,9 @@ def test_build_record_id(record):
 
 
 NIGHTLY_FILENAMES = [
-    ("firefox-55.0a1.en-US.linux-x86_64.tar.bz2", "55.0a1", "en-US", "linux-x86_64")
+    ("firefox-55.0a1.en-US.linux-x86_64.tar.bz2", "55.0a1", "en-US", "linux-x86_64"),
+    ("fennec-55.0a1.multi.android-i386.apk", "55.0a1", "multi", "android-i386"),
+    ("fennec-55.0a1.multi.android-arm.apk", "55.0a1", "multi", "android-arm"),
 ]
 
 


### PR DESCRIPTION
Refs #69 

- [ ] Add unittests for the URL parsing.

This tests shows that with the right record, the ID is correct. Which means that we don't build the right record for the Fennec nightly URLs.