### PR TITLE
Fix #89: Update filters so they act like a form.

### DIFF
--- a/ui/src/Main.elm
+++ b/ui/src/Main.elm
@@ -94,12 +94,15 @@ update msg ({ filterValues } as model) =
 
                         NewBuildIdSearch value ->
                             { noFilters | buildIdFilter = value }
-
-                updatedModelWithRoute =
-                    { model | route = routeFromFilters updatedModelWithFilters }
             in
-                { updatedModelWithRoute | loading = True }
-                    ! [ newUrl <| urlFromRoute updatedModelWithRoute.route ]
+                updatedModelWithFilters ! []
+
+        SubmitFilters ->
+            let
+                route =
+                    routeFromFilters model
+            in
+                { model | route = route } ! [ newUrl <| urlFromRoute route ]
 
         UrlChange location ->
             let

--- a/ui/src/Types.elm
+++ b/ui/src/Types.elm
@@ -19,6 +19,7 @@ import Kinto
 import Navigation exposing (..)
 
 
+pageSize : Int
 pageSize =
     10
 
@@ -155,3 +156,4 @@ type Msg
     | BuildRecordsNextPageFetched (Result Kinto.Error (Kinto.Pager BuildRecord))
     | UpdateFilter NewFilter
     | UrlChange Location
+    | SubmitFilters

--- a/ui/src/Types.elm
+++ b/ui/src/Types.elm
@@ -141,12 +141,12 @@ type alias Locale =
 
 type Route
     = MainView
-    | BuildIdView BuildId
     | ProductView Product
     | ChannelView Product Channel
     | PlatformView Product Channel Platform
     | VersionView Product Channel Platform Version
     | LocaleView Product Channel Platform Version Locale
+    | BuildIdView Product Channel Platform Version Locale BuildId
     | DocsView
 
 

--- a/ui/src/Url.elm
+++ b/ui/src/Url.elm
@@ -13,10 +13,6 @@ routeFromUrl model location =
                 (oneOf
                     [ map DocsView (s "docs" </> top)
                     , map MainView (s "builds" </> top)
-                    , map BuildIdView
-                        (s "builds"
-                            </> (s "buildId" </> string)
-                        )
                     , map ProductView
                         (s "builds"
                             </> (s "product" </> string)
@@ -47,6 +43,15 @@ routeFromUrl model location =
                             </> (s "version" </> string)
                             </> (s "locale" </> string)
                         )
+                    , map BuildIdView
+                        (s "builds"
+                            </> (s "product" </> string)
+                            </> (s "channel" </> string)
+                            </> (s "platform" </> string)
+                            </> (s "version" </> string)
+                            </> (s "locale" </> string)
+                            </> (s "buildId" </> string)
+                        )
                     ]
                 )
                 location
@@ -55,15 +60,15 @@ routeFromUrl model location =
             Just DocsView ->
                 { model | route = DocsView }
 
-            Just (BuildIdView buildId) ->
+            Just (BuildIdView product channel platform version locale buildId) ->
                 { model
-                    | route = BuildIdView buildId
+                    | route = BuildIdView product channel platform version locale buildId
                     , buildIdFilter = buildId
-                    , productFilter = "all"
-                    , channelFilter = "all"
-                    , platformFilter = "all"
-                    , versionFilter = "all"
-                    , localeFilter = "all"
+                    , productFilter = product
+                    , channelFilter = channel
+                    , platformFilter = platform
+                    , versionFilter = version
+                    , localeFilter = locale
                 }
 
             Just (ProductView product) ->
@@ -139,9 +144,6 @@ urlFromRoute route =
         DocsView ->
             "#/docs/"
 
-        BuildIdView buildId ->
-            "#/builds/buildId/" ++ buildId
-
         ProductView product ->
             "#/builds/product/" ++ product
 
@@ -181,6 +183,20 @@ urlFromRoute route =
                 ++ "/locale/"
                 ++ locale
 
+        BuildIdView product channel platform version locale buildId ->
+            "#/builds/product/"
+                ++ product
+                ++ "/channel/"
+                ++ channel
+                ++ "/platform/"
+                ++ platform
+                ++ "/version/"
+                ++ version
+                ++ "/locale/"
+                ++ locale
+                ++ "/buildId/"
+                ++ buildId
+
         _ ->
             "#/builds/"
 
@@ -188,7 +204,7 @@ urlFromRoute route =
 routeFromFilters : Model -> Route
 routeFromFilters { buildIdFilter, localeFilter, versionFilter, platformFilter, channelFilter, productFilter } =
     if buildIdFilter /= "" then
-        BuildIdView buildIdFilter
+        BuildIdView productFilter channelFilter platformFilter versionFilter localeFilter buildIdFilter
     else if localeFilter /= "all" then
         LocaleView productFilter channelFilter platformFilter versionFilter localeFilter
     else if versionFilter /= "all" then

--- a/ui/src/View.elm
+++ b/ui/src/View.elm
@@ -38,7 +38,6 @@ mainView model =
                 [ div [ class "panel-heading" ] [ strong [] [ text "Filters" ] ]
                 , Html.form [ class "panel-body", onSubmit <| SubmitFilters ]
                     [ buildIdSearchForm model
-                    , div [ style [ ( "text-align", "center" ) ] ] [ text " -- or -- " ]
                     , filterSelector model.filterValues.productList "Products" model.productFilter (UpdateFilter << NewProductFilter)
                     , filterSelector model.filterValues.versionList "Versions" model.versionFilter (UpdateFilter << NewVersionFilter)
                     , filterSelector model.filterValues.platformList "Platforms" model.platformFilter (UpdateFilter << NewPlatformFilter)

--- a/ui/src/View.elm
+++ b/ui/src/View.elm
@@ -36,7 +36,7 @@ mainView model =
         , div [ class "col-sm-3" ]
             [ div [ class "panel panel-default" ]
                 [ div [ class "panel-heading" ] [ strong [] [ text "Filters" ] ]
-                , div [ class "panel-body" ]
+                , Html.form [ class "panel-body", onSubmit <| SubmitFilters ]
                     [ buildIdSearchForm model
                     , div [ style [ ( "text-align", "center" ) ] ] [ text " -- or -- " ]
                     , filterSelector model.filterValues.productList "Products" model.productFilter (UpdateFilter << NewProductFilter)
@@ -44,10 +44,17 @@ mainView model =
                     , filterSelector model.filterValues.platformList "Platforms" model.platformFilter (UpdateFilter << NewPlatformFilter)
                     , filterSelector model.filterValues.channelList "Channels" model.channelFilter (UpdateFilter << NewChannelFilter)
                     , filterSelector model.filterValues.localeList "Locales" model.localeFilter (UpdateFilter << NewLocaleFilter)
-                    , p [ class "text-right" ]
-                        [ button
-                            [ class "btn btn-default", type_ "button", onClick (UpdateFilter ClearAll) ]
-                            [ text "Clear all filters" ]
+                    , div [ class "btn-group btn-group-justified" ]
+                        [ div [ class "btn-group" ]
+                            [ button
+                                [ class "btn btn-default", type_ "button", onClick (UpdateFilter ClearAll) ]
+                                [ text "Reset" ]
+                            ]
+                        , div [ class "btn-group" ]
+                            [ button
+                                [ class "btn btn-default btn-primary", type_ "submit" ]
+                                [ text "Search" ]
+                            ]
                         ]
                     ]
                 ]


### PR DESCRIPTION
Fixes #89. This patch wraps current filters into a form you submit as a whole everytime you want to refine your current search.

### Pros

- It saves a bunch of http requests
- It reallows filtering build ids along other filters

### Cons 

- Usage is a little less *dynamic* as you need to submit the form to run a search.

Thoughts?