### PR TITLE
Fix esr channel detection for Firefox.

### DIFF
--- a/jobs/buildhub/utils.py
+++ b/jobs/buildhub/utils.py
@@ -32,9 +32,10 @@ def guess_channel(url, version):
             channel = 'aurora'
         else:
             channel = 'nightly'
-    else:
-        if 'b' in version:
-            channel = 'beta'
+    elif 'b' in version:
+        channel = 'beta'
+    elif version.endswith('esr'):
+        channel = 'esr'
 
     # Fennec can have different app store ids.
     if 'old-id' in url:

--- a/jobs/tests/test_utils.py
+++ b/jobs/tests/test_utils.py
@@ -98,7 +98,7 @@ RECORDS = [
 
     # Firefox ESR
     {
-        "id": "firefox_52-0esr_linux-x86_64_en-us",
+        "id": "firefox_esr_52-0esr_linux-x86_64_en-us",
         "source": {
             "product": "firefox",
         },
@@ -106,7 +106,7 @@ RECORDS = [
             "version": "52.0esr",
             "platform": "linux-x86_64",
             "locale": "en-US",
-            "channel": "release"
+            "channel": "esr"
         },
         "download": {
             "url": "https://archive.mozilla.org/pub/firefox/releases/52.0esr/linux-x86_64/en-US/"

--- a/jobs/tests/test_utils.py
+++ b/jobs/tests/test_utils.py
@@ -170,7 +170,7 @@ RECORDS = [
 
     # Thunderbird Mac OS X Release
     {
-        "id": "thunderbird_10-0-12esr_macosx_pt-br",
+        "id": "thunderbird_esr_10-0-12esr_macosx_pt-br",
         "source": {
             "product": "thunderbird",
         },
@@ -178,7 +178,7 @@ RECORDS = [
             "version": "10.0.12esr",
             "platform": "macosx",
             "locale": "pt-BR",
-            "channel": "release"
+            "channel": "esr"
         },
         "download": {
             "url": "https://archive.mozilla.org/pub/thunderbird/releases/10.0.12esr/mac/pt-BR/"
@@ -188,7 +188,7 @@ RECORDS = [
 
     # Thunderbird Release
     {
-        "id": "thunderbird_17-0-8esr_linux-x86_64_gd",
+        "id": "thunderbird_esr_17-0-8esr_linux-x86_64_gd",
         "source": {
             "product": "thunderbird",
         },
@@ -196,7 +196,7 @@ RECORDS = [
             "version": "17.0.8esr",
             "platform": "linux-x86_64",
             "locale": "gd",
-            "channel": "release"
+            "channel": "esr"
         },
         "download": {
             "url": "https://archive.mozilla.org/pub/thunderbird/releases/17.0.8esr/linux-x86_64/"

--- a/jobs/tox.ini
+++ b/jobs/tox.ini
@@ -5,7 +5,7 @@ skip_missing_interpreters = True
 [testenv]
 usedevelop=true
 commands =
-    py.test --cov-report term-missing --cov buildhub {posargs}
+    py.test --cov-report term-missing --cov buildhub tests {posargs}
 deps =
     -rdev-requirements.txt
 


### PR DESCRIPTION
I was looking over the buildhub code and discovered that it doesn't detect "channel" for Firefox ESRs correctly - it sets it to "release" instead of "esr". This patch fixes that, but still needs to be updated to either make it work for Thunderbird (or fix the tests if it already does).

Thunderbird is a bit of a weird case because their "release" channel is built out of ESR repositories - so it's not exactly comparable to Firefox.