### PR TITLE
Use archive inventory and limit products to process (Fixes #193)

### DIFF
--- a/jobs/README.rst
+++ b/jobs/README.rst
@@ -35,13 +35,13 @@ List available manifests in inventories folder:
 
 .. code-block:: bash
 
-    aws --no-sign-request --region us-east-1 s3 ls "s3://net-mozaws-prod-delivery-inventory-us-east-1/public/inventories/net-mozaws-prod-delivery-firefox/delivery-firefox/"
+    aws --no-sign-request --region us-east-1 s3 ls "s3://net-mozaws-prod-delivery-inventory-us-east-1/public/inventories/net-mozaws-prod-delivery-archive/delivery-archive/"
 
 Download the latest manifest:
 
 .. code-block:: bash
 
-    aws --no-sign-request --region us-east-1 s3 cp s3://net-mozaws-prod-delivery-inventory-us-east-1/public/inventories/net-mozaws-prod-delivery-firefox/delivery-firefox/2017-07-13T00-09Z/manifest.json
+    aws --no-sign-request --region us-east-1 s3 cp s3://net-mozaws-prod-delivery-inventory-us-east-1/public/inventories/net-mozaws-prod-delivery-archive/delivery-archive/2017-08-02T00-11Z/manifest.json
 
 Download the associated files (using `jq <https://stedolan.github.io/jq/download/>`_):
 

--- a/jobs/README.rst
+++ b/jobs/README.rst
@@ -31,17 +31,23 @@ In order to fetch inventories from S3, install the dedicated Amazon Services cli
 
    sudo apt-get install awscli
 
-List available manifests in inventories folder:
+We are interested in two listing: ``firefox`` and ``archive`` (thunderbird, mobile).
 
 .. code-block:: bash
 
-    aws --no-sign-request --region us-east-1 s3 ls "s3://net-mozaws-prod-delivery-inventory-us-east-1/public/inventories/net-mozaws-prod-delivery-archive/delivery-archive/"
+    export LISTING=archive
+
+List available manifests in the inventories folder:
+
+.. code-block:: bash
+
+    aws --no-sign-request --region us-east-1 s3 ls "s3://net-mozaws-prod-delivery-inventory-us-east-1/public/inventories/net-mozaws-prod-delivery-$LISTING/delivery-$LISTING/"
 
 Download the latest manifest:
 
 .. code-block:: bash
 
-    aws --no-sign-request --region us-east-1 s3 cp s3://net-mozaws-prod-delivery-inventory-us-east-1/public/inventories/net-mozaws-prod-delivery-archive/delivery-archive/2017-08-02T00-11Z/manifest.json
+    aws --no-sign-request --region us-east-1 s3 cp s3://net-mozaws-prod-delivery-inventory-us-east-1/public/inventories/net-mozaws-prod-delivery-$LISTING/delivery-$LISTING/2017-08-02T00-11Z/manifest.json
 
 Download the associated files (using `jq <https://stedolan.github.io/jq/download/>`_):
 
@@ -69,6 +75,8 @@ Load records into Kinto:
 .. code-block:: bash
 
     cat records.data | to-kinto --server https://kinto/ --bucket build-hub --collection release --auth user:pass initialization.yaml
+
+Repeat with ``LISTING=firefox``.
 
 
 System-Addons updates

--- a/jobs/buildhub/inventory_to_records.py
+++ b/jobs/buildhub/inventory_to_records.py
@@ -138,7 +138,7 @@ async def scan_candidates(session, product):
     if product in _candidates_build_folder:
         return
 
-    logger.info("Scan candidates to get their latest build folder...")
+    logger.info("Scan '{}' candidates to get their latest build folder...".format(product))
     candidates_url = archive_url(product, candidate="/")
     candidates_folders, _ = await fetch_listing(session, candidates_url)
 
@@ -259,7 +259,11 @@ async def csv_to_records(loop, stdin, stdout):
             for entry in entries:
                 object_key = entry["Key"]
 
-                product = object_key.split('/')[1]  # pub/thunderbird/nightly/...
+                try:
+                    product = object_key.split('/')[1]  # /pub/thunderbird/nightly/...
+                except IndexError:
+                    continue  # e.g. https://archive.mozilla.org/favicon.ico
+
                 if product not in PRODUCTS:
                     continue
 

--- a/jobs/buildhub/inventory_to_records.py
+++ b/jobs/buildhub/inventory_to_records.py
@@ -257,10 +257,9 @@ async def csv_to_records(loop, stdin, stdout):
             entries = deduplicate_windows_entries(entries)
 
             for entry in entries:
-                bucket_name = entry["Bucket"]
                 object_key = entry["Key"]
 
-                product = bucket_name.split('-')[-1]
+                product = object_key.split('/')[1]  # pub/thunderbird/nightly/...
                 if product not in PRODUCTS:
                     continue
 

--- a/jobs/buildhub/inventory_to_records.py
+++ b/jobs/buildhub/inventory_to_records.py
@@ -21,6 +21,7 @@ from .utils import (archive_url, chunked, is_release_metadata, is_release_url,
 NB_PARALLEL_REQUESTS = int(os.getenv("NB_PARALLEL_REQUESTS", 8))
 NB_RETRY_REQUEST = int(os.getenv("NB_RETRY_REQUEST", 3))
 TIMEOUT_SECONDS = int(os.getenv("TIMEOUT_SECONDS", 5 * 60))
+PRODUCTS = os.getenv("PRODUCTS", "firefox thunderbird mobile").split(" ")
 
 
 logger = logging.getLogger(__name__)
@@ -260,6 +261,8 @@ async def csv_to_records(loop, stdin, stdout):
                 object_key = entry["Key"]
 
                 product = bucket_name.split('-')[-1]
+                if product not in PRODUCTS:
+                    continue
 
                 # Scan the list of candidates metadata (no-op if already initialized).
                 await scan_candidates(session, product)

--- a/jobs/buildhub/inventory_to_records.py
+++ b/jobs/buildhub/inventory_to_records.py
@@ -146,7 +146,7 @@ async def scan_candidates(session, product):
         futures = []
         versions = []
         for folder in chunk:
-            if folder == "archived/":
+            if "-candidates" not in folder:
                 continue
             version = folder.replace("-candidates/", "")
             versions.append(version)

--- a/jobs/buildhub/utils.py
+++ b/jobs/buildhub/utils.py
@@ -120,9 +120,9 @@ def is_release_url(product, url):
     if 'nightly' in url and 'mozilla-central' not in url:
         return False
 
-    re_exclude = re.compile(".+(tinderbox|partner-repacks|latest|contrib|/0\.|"
+    re_exclude = re.compile(".+(tinderbox|try-builds|partner-repacks|latest|contrib|/0\.|"
                             "experimental|debug|sha1-installers|candidates|"
-                            "stylo-bindings)")
+                            "stylo-bindings|/1.0rc/|dominspector|/test/)")
     if re_exclude.match(url):
         return False
     """

--- a/jobs/tests/data/inventory-simple.csv
+++ b/jobs/tests/data/inventory-simple.csv
@@ -1,3 +1,4 @@
-net-mozaws-delivery-firefox,pub/firefox/nightly/2017/05/2017-05-15-10-02-38-mozilla-central/firefox-55.0a1.en-US.linux-x86_64.tar.bz2,50000,2017-06-02T12:20:10.2Z,f1aa742ef0973db098947bd6d875f193
-net-mozaws-delivery-firefox,pub/firefox/nightly/2017/06/2017-06-02-03-02-04-mozilla-central-l10n/firefox-55.0a1.ach.win32.complete.mar,50000,2017-06-02T12:20:10.2Z,a7fa24fe01973db09894bd6d7875f391
-net-mozaws-delivery-firefox,pub/firefox/releases/52.0/linux-x86_64/fr/firefox-52.0.tar.bz2,60000,2017-06-02T15:20:10.4Z,1afa742ef0973db098947bd6d8759f13
+"net-mozaws-delivery-firefox","pub/firefox/nightly/2017/05/2017-05-15-10-02-38-mozilla-central/firefox-55.0a1.en-US.linux-x86_64.tar.bz2","50000","2017-06-02T12:20:10.2Z","f1aa742ef0973db098947bd6d875f193"
+"net-mozaws-delivery-firefox","pub/firefox/nightly/2017/06/2017-06-02-03-02-04-mozilla-central-l10n/firefox-55.0a1.ach.win32.complete.mar","50000","2017-06-02T12:20:10.2Z","a7fa24fe01973db09894bd6d7875f391"
+"net-mozaws-delivery-firefox","pub/firefox/releases/52.0/linux-x86_64/fr/firefox-52.0.tar.bz2","60000","2017-06-02T15:20:10.4Z","1afa742ef0973db098947bd6d8759f13"
+"net-mozaws-prod-delivery-archive","pub/thunderbird/candidates/aurora-beta-channel-switch/update.mar","1502","2017-07-03T04:08:13.000Z","2c9a96bdfc62b8d43fe2f4c587454b6f"

--- a/jobs/tests/test_utils.py
+++ b/jobs/tests/test_utils.py
@@ -587,6 +587,11 @@ WRONG_RELEASE_FILENAMES = [
     ("firefox", ("/candidates/51.0.1-candidates/build3/funnelcake99-testing/v1/win32/en-US/"
                  "firefox-51.0.1.en-US.win32.installer.exe")),
     ("firefox", "firefox-56.0a1.en-US.win64.stylo-bindings.zip"),
+    ("thunderbird", "/pub/thunderbird/releases/1.0rc/thunderbird-1.0rc-win32.zip"),
+    ("thunderbird", "/pub/thunderbird/extensions/inspector/thunderbird-dominspector-0.9%2B.zip"),
+    ("thunderbird", "/pub/thunderbird/test/inlinespellcheck-test-build/thunderbird-win32.zip"),
+    ("thunderbird", "/pub/thunderbird/test/standard8-jmalloc-test/special-test-no-jemalloc.exe"),
+    ("firefox", "/pub/firefox/try-builds/jg%40m.com-e/try-win64/firefox-56.0a1.en-US.win64.zip"),
 ]
 
 


### PR DESCRIPTION
Fixes #193 

* [x] To be fully honest, I haven't checked if the `archive` also contains firefox, but it has thunderbird and mobile :)
* [x] Deduce product from key and not bucket name
* [x] Update tests

