### PR TITLE
Lambda to load S3 inventories  (fixes #197)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
-python: 3.5
+python: 3.6
 cache: pip
 env:
-  - TOX_ENV=py35
+  - TOX_ENV=py36
   - TOX_ENV=flake8
 install:
   - pip install tox
@@ -19,9 +19,6 @@ after_success:
   - coveralls
 matrix:
   include:
-    - python: 3.6
-      env:
-        - TOX_ENV=py36
     - language: node_js
       node_js: 7
       install:

--- a/jobs/buildhub/inventory_to_records.py
+++ b/jobs/buildhub/inventory_to_records.py
@@ -16,7 +16,7 @@ import backoff
 from buildhub.utils import (
     archive_url, chunked, is_release_build_metadata, is_build_url,
     record_from_url, localize_nightly_url, merge_metadata, check_record,
-    localize_release_candidate_url,
+    localize_release_candidate_url, stream_as_generator,
     ARCHIVE_URL, FILE_EXTENSIONS, DATETIME_FORMAT, ALL_PRODUCTS)
 
 
@@ -358,18 +358,6 @@ async def csv_to_records(loop, stdin):
 
         async for result in process_batch(session, batch):  # Last loop iteration.
             yield result
-
-
-async def stream_as_generator(loop, stream):
-    reader = asyncio.StreamReader(loop=loop)
-    reader_protocol = asyncio.StreamReaderProtocol(reader)
-    await loop.connect_read_pipe(lambda: reader_protocol, stream)
-
-    while "stream receives input":
-        line = await reader.readline()
-        if not line:  # EOF.
-            break
-        yield line
 
 
 async def main(loop):

--- a/jobs/buildhub/inventory_to_records.py
+++ b/jobs/buildhub/inventory_to_records.py
@@ -26,7 +26,7 @@ TIMEOUT_SECONDS = int(os.getenv("TIMEOUT_SECONDS", 5 * 60))
 PRODUCTS = os.getenv("PRODUCTS", " ".join(ALL_PRODUCTS)).split(" ")
 
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()  # root logger.
 
 
 async def read_csv(input_generator):

--- a/jobs/buildhub/inventory_to_records.py
+++ b/jobs/buildhub/inventory_to_records.py
@@ -13,10 +13,11 @@ from collections import defaultdict
 import aiohttp
 import backoff
 
-from .utils import (archive_url, chunked, is_release_build_metadata, is_build_url,
-                    record_from_url, localize_nightly_url, merge_metadata, check_record,
-                    localize_release_candidate_url,
-                    ARCHIVE_URL, FILE_EXTENSIONS, DATETIME_FORMAT, ALL_PRODUCTS)
+from buildhub.utils import (
+    archive_url, chunked, is_release_build_metadata, is_build_url,
+    record_from_url, localize_nightly_url, merge_metadata, check_record,
+    localize_release_candidate_url,
+    ARCHIVE_URL, FILE_EXTENSIONS, DATETIME_FORMAT, ALL_PRODUCTS)
 
 
 NB_PARALLEL_REQUESTS = int(os.getenv("NB_PARALLEL_REQUESTS", 8))
@@ -28,11 +29,21 @@ PRODUCTS = os.getenv("PRODUCTS", " ".join(ALL_PRODUCTS)).split(" ")
 logger = logging.getLogger(__name__)
 
 
-def read_csv(stream):
+async def read_csv(input_generator):
+    """
+    :param input_generator: async generator of raw bytes
+    """
     fieldnames = ["Bucket", "Key", "Size", "LastModifiedDate", "md5"]
-    reader = csv.DictReader(stream, fieldnames=fieldnames)
-    for row in reader:
-        yield row
+
+    leftover = ''
+    async for csv_chunk in input_generator:
+        chunk_str = csv_chunk.decode("utf-8")
+        lines = (leftover + chunk_str).split("\n")
+        leftover = lines.pop()
+        if lines:
+            reader = csv.DictReader(lines, fieldnames=fieldnames)
+            for row in reader:
+                yield row
 
 
 @backoff.on_exception(backoff.expo,
@@ -248,7 +259,7 @@ async def fetch_release_metadata(session, record):
     raise ValueError("Missing metadata for candidate {}".format(url))
 
 
-async def process_batch(session, batch, stdout):
+async def process_batch(session, batch):
     # Parallel fetch of metadata for each item of the batch.
     logger.info("Fetch metadata for {} releases...".format(len(batch)))
     futures = [fetch_metadata(session, record) for record in batch]
@@ -260,16 +271,18 @@ async def process_batch(session, batch, stdout):
             check_record(result)
         except ValueError as e:
             logger.warning(e)
-        stdout.write(json.dumps({"data": result}) + "\n")
-    return results
+        yield {"data": result}
 
 
-async def csv_to_records(loop, stdin, stdout):
+async def csv_to_records(loop, stdin):
+    """
+    :rtype: async generator of records (dict-like)
+    """
 
-    def inventory_by_folder(stdin):
+    async def inventory_by_folder(stdin):
         previous = None
         result = []
-        for entry in read_csv(stdin):
+        async for entry in read_csv(stdin):
             object_key = entry["Key"]
             folder = os.path.dirname(object_key)
 
@@ -302,7 +315,7 @@ async def csv_to_records(loop, stdin, stdout):
     async with aiohttp.ClientSession(loop=loop) as session:
         batch = []
 
-        for entries in inventory_by_folder(stdin):
+        async for entries in inventory_by_folder(stdin):
 
             entries = deduplicate_entries(entries)
 
@@ -338,11 +351,25 @@ async def csv_to_records(loop, stdin, stdout):
                 if len(batch) < NB_PARALLEL_REQUESTS:
                     batch.append(record)
                 else:
-                    await process_batch(session, batch, stdout)
+                    async for result in process_batch(session, batch):
+                        yield result
 
                     batch = []  # Go on.
 
-        await process_batch(session, batch, stdout)  # Last loop iteration.
+        async for result in process_batch(session, batch):  # Last loop iteration.
+            yield result
+
+
+async def stream_as_generator(loop, stream):
+    reader = asyncio.StreamReader(loop=loop)
+    reader_protocol = asyncio.StreamReaderProtocol(reader)
+    await loop.connect_read_pipe(lambda: reader_protocol, stream)
+
+    while "stream receives input":
+        line = await reader.readline()
+        if not line:  # EOF.
+            break
+        yield line
 
 
 async def main(loop):
@@ -363,7 +390,8 @@ async def main(loop):
     else:
         logger.setLevel(logging.WARNING)
 
-    await csv_to_records(loop, sys.stdin, sys.stdout)
+    async for record in csv_to_records(loop, stream_as_generator(loop, sys.stdin)):
+        sys.stdout.write(json.dumps(record) + "\n")
 
 
 def run():

--- a/jobs/buildhub/lambda_s3_inventory.py
+++ b/jobs/buildhub/lambda_s3_inventory.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 import os.path
 import zlib
 
@@ -15,6 +16,9 @@ REGION_NAME = 'us-east-1'
 BUCKET = "net-mozaws-prod-delivery-inventory-us-east-1"
 FOLDER = "public/inventories/net-mozaws-prod-delivery-{inventory}/delivery-{inventory}/"
 CHUNK_SIZE = 1024
+
+
+logger = logging.getLogger()  # root logger.
 
 
 async def list_manifest_entries(loop, client, inventory):
@@ -75,6 +79,10 @@ async def main(loop, event, inventory):
 
 
 def lambda_handler(event, context):
+    # Log everything to stderr.
+    logger.addHandler(logging.StreamHandler())
+    logger.setLevel(logging.DEBUG)
+
     loop = asyncio.get_event_loop()
     for inventory in ("firefox", "archive"):
         loop.run_until_complete(main(loop, event, inventory))

--- a/jobs/buildhub/lambda_s3_inventory.py
+++ b/jobs/buildhub/lambda_s3_inventory.py
@@ -1,0 +1,62 @@
+import asyncio
+import aiobotocore
+import gzip
+import json
+import os.path
+from io import BytesIO, StringIO
+
+from buildhub.inventory_to_records import csv_to_records
+
+BUCKET = "net-mozaws-prod-delivery-inventory-us-east-1"
+FOLDER = "public/inventories/net-mozaws-prod-delivery-{inventory}/delivery-{inventory}/"
+
+
+async def handle_file(loop, client, file_key):
+    # 2. For each inventory file, convert it to records and populate Kinto
+    gzipped_csv_file = await client.get_object(Bucket=BUCKET, Key=file_key)
+    async with gzipped_csv_file['Body'] as stream:
+        gzipped_body = await stream.read()
+        gzip_fd = BytesIO(gzipped_body)
+        with gzip.open(gzip_fd, 'rb') as csv_fd:
+            json_fd = StringIO()
+            await csv_to_records(loop, csv_fd, json_fd)
+            print(json_fd.getvalue())
+
+
+async def main(loop, event, inventory):
+    """
+    Trigger to populate kinto with the last inventories.
+    """
+    # 0. Get the last inventory date and download its manifest.json
+    session = aiobotocore.get_session(loop=loop)
+    async with session.create_client('s3', region_name='us-east-1') as client:
+        paginator = client.get_paginator('list_objects')
+        inventory_folder = FOLDER.format(inventory=inventory)
+        async for result in paginator.paginate(Bucket=BUCKET, Prefix=inventory_folder,
+                                               Delimiter='/'):
+            files = list(result.get('CommonPrefixes', []))
+            last_inventory = os.path.basename(files[-2]['Prefix'].strip('/'))  # -1 is data
+            # Download manifest.json
+            key = '{}{}/manifest.json'.format(inventory_folder, last_inventory)
+            manifest = await client.get_object(Bucket=BUCKET, Key=key)
+            async with manifest['Body'] as stream:
+                body = await stream.read()
+            manifest_content = json.loads(body.decode('utf-8'))
+            print(manifest_content)
+            files = [f['key'] for f in manifest_content['files']]
+
+            # 1. Download Firefox and Archives inventories in S3
+            for file_key in files:
+                await handle_file(loop, client, file_key)
+                break
+
+
+def get_lambda_handler(inventory):
+    def lambda_handler(event, context):
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(main(loop, event, inventory))
+        loop.close()
+    return lambda_handler
+
+firefox_inventory_handler = get_lambda_handler("firefox")
+archive_inventory_handler = get_lambda_handler("archive")

--- a/jobs/buildhub/lambda_s3_inventory.py
+++ b/jobs/buildhub/lambda_s3_inventory.py
@@ -1,62 +1,82 @@
 import asyncio
 import aiobotocore
-import gzip
+import botocore
 import json
 import os.path
-from io import BytesIO, StringIO
+import zlib
 
 from buildhub.inventory_to_records import csv_to_records
+from buildhub.to_kinto import main as to_kinto
 
+
+REGION_NAME = 'us-east-1'
 BUCKET = "net-mozaws-prod-delivery-inventory-us-east-1"
 FOLDER = "public/inventories/net-mozaws-prod-delivery-{inventory}/delivery-{inventory}/"
+CHUNK_SIZE = 1024
 
 
-async def handle_file(loop, client, file_key):
-    # 2. For each inventory file, convert it to records and populate Kinto
-    gzipped_csv_file = await client.get_object(Bucket=BUCKET, Key=file_key)
-    async with gzipped_csv_file['Body'] as stream:
-        gzipped_body = await stream.read()
-        gzip_fd = BytesIO(gzipped_body)
-        with gzip.open(gzip_fd, 'rb') as csv_fd:
-            json_fd = StringIO()
-            await csv_to_records(loop, csv_fd, json_fd)
-            print(json_fd.getvalue())
+async def list_manifest_entries(loop, client, inventory):
+    prefix = FOLDER.format(inventory=inventory)
+    paginator = client.get_paginator('list_objects')
+    async for result in paginator.paginate(Bucket=BUCKET, Prefix=prefix, Delimiter='/'):
+        # Take latest inventory.
+        files = list(result.get('CommonPrefixes', []))
+        last_inventory = os.path.basename(files[-2]['Prefix'].strip('/'))  # -1 is data
+        # Download manifest.json
+        key = '{}{}/manifest.json'.format(prefix, last_inventory)
+        manifest = await client.get_object(Bucket=BUCKET, Key=key)
+        async with manifest['Body'] as stream:
+            body = await stream.read()
+        manifest_content = json.loads(body.decode('utf-8'))
+        # Return keys of csv.gz files
+        for f in manifest_content['files']:
+            yield f['key']
+
+
+async def download_csv(loop, client, keys_stream, chunk_size=CHUNK_SIZE):
+    gzip = zlib.decompressobj(zlib.MAX_WBITS | 16)
+
+    async for key in keys_stream:
+        key = "public/" + key
+        file_csv_gz = await client.get_object(Bucket=BUCKET, Key=key)
+        async with file_csv_gz['Body'] as stream:
+            while "there are chunks to read":
+                gzip_chunk = await stream.read(chunk_size)
+                if not gzip_chunk:
+                    break
+                csv_chunk = gzip.decompress(gzip_chunk)
+                yield csv_chunk
 
 
 async def main(loop, event, inventory):
     """
     Trigger to populate kinto with the last inventories.
     """
-    # 0. Get the last inventory date and download its manifest.json
+    server_url = os.getenv("SERVER_URL", "http://localhost:8888/v1")
+    bucket = os.getenv("BUCKET", "default")
+    collection = os.getenv("COLLECTION", "releases")
+    kinto_auth = os.getenv("AUTH", "user:pass")
+
     session = aiobotocore.get_session(loop=loop)
-    async with session.create_client('s3', region_name='us-east-1') as client:
-        paginator = client.get_paginator('list_objects')
-        inventory_folder = FOLDER.format(inventory=inventory)
-        async for result in paginator.paginate(Bucket=BUCKET, Prefix=inventory_folder,
-                                               Delimiter='/'):
-            files = list(result.get('CommonPrefixes', []))
-            last_inventory = os.path.basename(files[-2]['Prefix'].strip('/'))  # -1 is data
-            # Download manifest.json
-            key = '{}{}/manifest.json'.format(inventory_folder, last_inventory)
-            manifest = await client.get_object(Bucket=BUCKET, Key=key)
-            async with manifest['Body'] as stream:
-                body = await stream.read()
-            manifest_content = json.loads(body.decode('utf-8'))
-            print(manifest_content)
-            files = [f['key'] for f in manifest_content['files']]
+    boto_config = botocore.config.Config(signature_version=botocore.UNSIGNED)
+    async with session.create_client('s3', region_name=REGION_NAME, config=boto_config) as client:
 
-            # 1. Download Firefox and Archives inventories in S3
-            for file_key in files:
-                await handle_file(loop, client, file_key)
-                break
+        keys_stream = list_manifest_entries(loop, client, inventory)
+        csv_stream = download_csv(loop, client, keys_stream)
+        records_stream = csv_to_records(loop, csv_stream)
+
+        await to_kinto(loop, records_stream,
+                       '--skip', '--server', server_url,
+                       '--bucket', bucket, '--collection', collection,
+                       '--auth', kinto_auth)
 
 
-def get_lambda_handler(inventory):
-    def lambda_handler(event, context):
-        loop = asyncio.get_event_loop()
+def lambda_handler(event, context):
+    loop = asyncio.get_event_loop()
+    for inventory in ("firefox", "archive"):
         loop.run_until_complete(main(loop, event, inventory))
-        loop.close()
-    return lambda_handler
+    loop.close()
 
-firefox_inventory_handler = get_lambda_handler("firefox")
-archive_inventory_handler = get_lambda_handler("archive")
+
+if __name__ == "__main__":
+    lambda_handler(None, None)

--- a/jobs/buildhub/to_kinto.py
+++ b/jobs/buildhub/to_kinto.py
@@ -101,7 +101,7 @@ def publish_records(client, records):
 
 
 async def produce(loop, records, queue):
-    """Reads an asynchronuous generator of records and puts them into the queue.
+    """Reads an asynchronous generator of records and puts them into the queue.
     """
     async for record in records:
         if "data" not in record and "permission" not in record:

--- a/jobs/buildhub/utils.py
+++ b/jobs/buildhub/utils.py
@@ -234,21 +234,15 @@ async def split_lines(stream):
 
 
 async def stream_as_generator(loop, stream):
-    if not stream.isatty():
-        # Used in tests only, where stream is just a file descriptor.
-        # Workaround for "Pipe transport is for pipes/sockets only".
-        for line in stream.readlines():
-            yield bytes(line, "utf-8")
-    else:
-        reader = asyncio.StreamReader(loop=loop)
-        reader_protocol = asyncio.StreamReaderProtocol(reader)
-        await loop.connect_read_pipe(lambda: reader_protocol, stream)
+    reader = asyncio.StreamReader(loop=loop)
+    reader_protocol = asyncio.StreamReaderProtocol(reader)
+    await loop.connect_read_pipe(lambda: reader_protocol, stream)
 
-        while "stream receives input":
-            line = await reader.readline()
-            if not line:  # EOF.
-                break
-            yield line
+    while "stream receives input":
+        line = await reader.readline()
+        if not line:  # EOF.
+            break
+        yield line
 
 
 def record_from_url(url):

--- a/jobs/buildhub/utils.py
+++ b/jobs/buildhub/utils.py
@@ -222,12 +222,15 @@ def chunked(iterable, size):
 
 
 async def split_lines(stream):
+    """Split the chunks of bytes on new lines.
+    """
     leftover = ''
     async for chunk in stream:
         chunk_str = chunk.decode("utf-8")
         chunk_str = leftover + chunk_str
         chunk_str = chunk_str.lstrip("\n")
         lines = chunk_str.split("\n")
+        # Everything after \n belongs to the next line.
         leftover = lines.pop()
         if lines:
             yield lines

--- a/jobs/buildhub/utils.py
+++ b/jobs/buildhub/utils.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime
 import os.path
 import re
@@ -218,6 +219,18 @@ def chunked(iterable, size):
     nb_chunks = (len(iterable) // size) + 1
     for i in range(nb_chunks):
         yield iterable[(i * size):((i + 1) * size)]
+
+
+async def stream_as_generator(loop, stream):
+    reader = asyncio.StreamReader(loop=loop)
+    reader_protocol = asyncio.StreamReaderProtocol(reader)
+    await loop.connect_read_pipe(lambda: reader_protocol, stream)
+
+    while "stream receives input":
+        line = await reader.readline()
+        if not line:  # EOF.
+            break
+        yield line
 
 
 def record_from_url(url):

--- a/jobs/setup.py
+++ b/jobs/setup.py
@@ -18,6 +18,7 @@ CONTRIBUTORS = read_file('CONTRIBUTORS.rst')
 
 REQUIREMENTS = [
     "aiohttp",
+    "aiobotocore",
     "backoff",
     "kinto-http",
     "kinto-wizard",

--- a/jobs/setup.py
+++ b/jobs/setup.py
@@ -28,6 +28,7 @@ ENTRY_POINTS = {
     'console_scripts': [
         'to-kinto = buildhub.to_kinto:run',
         'inventory-to-records = buildhub.inventory_to_records:run',
+        'latest-inventory-to-kinto = buildhub.lambda_s3_inventory:lambda_handler',
     ],
 }
 

--- a/jobs/tests/test_lamdba_s3_inventory.py
+++ b/jobs/tests/test_lamdba_s3_inventory.py
@@ -1,0 +1,76 @@
+import base64
+
+import asynctest
+
+from buildhub.lambda_s3_inventory import list_manifest_entries, download_csv
+
+
+class ListManifest(asynctest.TestCase):
+    def setUp(self):
+        class FakePaginator:
+            async def paginate(self, *args, **kwargs):
+                yield {"CommonPrefixes": [{"Prefix": "1/"}]}
+                yield {"CommonPrefixes": [{"Prefix": "2/"}]}
+                yield {"CommonPrefixes": [{"Prefix": "3/"}, {"Prefix": "data"}]}
+
+        class FakeStream:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return self
+
+            async def read(self):
+                return b'{"files": [{"key": "a/b"}, {"key": "c/d"}]}'
+
+        class FakeClient:
+            def get_paginator(self, *args):
+                return FakePaginator()
+
+            async def get_object(self, Bucket, Key):
+                if Key.endswith("delivery-firefox/delivery-firefox/3/manifest.json"):
+                    return {'Body': FakeStream()}
+
+        self.client = FakeClient()
+
+    async def test_return_keys_of_latest_manifest(self):
+        results = []
+        async for r in list_manifest_entries(self.loop, self.client, "firefox"):
+            results.append(r)
+        assert results == ["a/b", "c/d"]
+
+
+class DownloadCSV(asynctest.TestCase):
+    def setUp(self):
+        class FakeStream:
+            async def __aenter__(self):
+                self.content = [
+                    # echo -n "1;2;3;4\n5;6" | gzip -cf | base64
+                    base64.b64decode("H4sIADPbllkAAzO0NrI2tjbhMrU2AwDZEJLXCwAAAA=="),
+                    None,
+                ]
+                return self
+
+            async def __aexit__(self, *args):
+                return self
+
+            async def read(self, size):
+                return self.content.pop(0)
+
+        class FakeClient:
+            async def get_object(self, Bucket, Key):
+                if Key.endswith("public/key-1"):
+                    return {'Body': FakeStream()}
+
+        self.client = FakeClient()
+
+    async def test_unzip_chunks(self):
+
+        async def keys():
+            yield "key-1"
+
+        keys = keys()
+        results = []
+        async for r in download_csv(self.loop, self.client, keys):
+            results.append(r)
+        assert results == [b"1;2;3;4\n5;6"]

--- a/jobs/tox.ini
+++ b/jobs/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,flake8
+envlist = py36,flake8
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
fixes #197

* [x] Change existing code to rely on generators
* [x] Implement lambda that chains generators (download, gunzip, parse csv, obtain metadata, load into kinto)
* [x] Refactor `to_kinto.py::main()` in order to take a kinto http client instance instead of raw CLI args
* [x] Add test for the new lambda
* [x] Fix tests to adjust to new spec
* [x] Moved `async def stream_as_generator(loop, stream)` to utils
* [x] Add debug logging


> **Note**: This PR drops support of Python 3.5 because we now use async generators of Python 3.6.