### PR TITLE
Handle devedition builds (fixes #188)

### DIFF
--- a/jobs/buildhub/utils.py
+++ b/jobs/buildhub/utils.py
@@ -4,7 +4,7 @@ import os.path
 import re
 
 
-ALL_PRODUCTS = ("firefox", "thunderbird", "mobile")
+ALL_PRODUCTS = ("firefox", "thunderbird", "mobile", "devedition")
 ARCHIVE_URL = "https://archive.mozilla.org/"
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 FILE_EXTENSIONS = "zip|tar.gz|tar.bz2|dmg|apk|exe"
@@ -21,7 +21,8 @@ KNOWN_MIMETYPES = {
 def archive_url(product, version=None, platform=None, locale=None, nightly=None, candidate=None):
     """Returns the related URL on archive.mozilla.org
     """
-    product = product if product != "fennec" else "mobile"
+    if product == "fennec":
+        product = "mobile"
 
     if platform is not None:
         platform = platform.replace('eme', 'EME')
@@ -190,6 +191,7 @@ def is_nightly_build_metadata(product, url):
         return False
     if product == "mobile":
         product = "fennec"
+    # Note: devedition has no nightly.
     re_metadata = re.compile(".+/{}-(.*)\.(.*)\.(.*)\.json$".format(product))
     return bool(re_metadata.match(url))
 
@@ -197,6 +199,8 @@ def is_nightly_build_metadata(product, url):
 def is_rc_build_metadata(product, url):
     if product == "mobile":
         product = "fennec"
+    if product == "devedition":
+        product = "firefox"
     m = re.search("/candidates/(.+)-candidates", url)
     if not m:
         return False
@@ -257,7 +261,9 @@ def record_from_url(url):
     filename = os.path.basename(normalized_url)
     filename_parts = filename.split('.')
 
-    product = filename_parts[0].replace('-setup', '').split('-')[0]
+    product = url_parts[4]
+    if product == "mobile":
+        product = "fennec"
 
     # Nightly URL
     # https://archive.mozilla.org/pub/firefox/nightly/2017/05/

--- a/jobs/tests/data/inventory-simple.csv
+++ b/jobs/tests/data/inventory-simple.csv
@@ -6,3 +6,4 @@
 "net-mozaws-prod-delivery-archive","pub/thunderbird/candidates/aurora-beta-channel-switch/update.mar","1502","2017-07-03T04:08:13.000Z","2c9a96bdfc62b8d43fe2f4c587454b6f"
 "net-mozaws-prod-delivery-firefox","pub/firefox/candidates/55.0b9-candidates/build2/win64/zh-TW/firefox-55.0b9.zip","53251778","2017-07-13T23:37:21.000Z","0315517f673697841a5e28ff44da2eb9"
 "net-mozaws-prod-delivery-firefox","pub/firefox/candidates/55.0b9-candidates/build2/win64/zh-TW/Firefox+Setup+55.0b9.exe","37219504","2017-07-13T23:37:23.000Z","ff391f7201575ab2ba518fce20d45596"
+"net-mozaws-prod-delivery-archive","pub/devedition/candidates/55.0b1-candidates/build5/win64/pt-BR/firefox-55.0b1.zip","53718907","2017-06-14T00:41:56.000Z","8eb5c067a880ca9c63a1bf0a6c9a631d"

--- a/jobs/tests/test_inventory_to_records_functional.py
+++ b/jobs/tests/test_inventory_to_records_functional.py
@@ -152,4 +152,33 @@ class CsvToRecordsTest(asynctest.TestCase):
                     'version': '55.0b9rc2'
                 }
             }
+        }, {
+            "data": {
+                "id": "devedition_aurora_55-0b1rc5_win64_pt-br",
+                "source": {
+                    "product": "devedition",
+                    "revision": "6872377277a618b2b9e0d2b4c2b9e51765ac199e",
+                    "repository": "https://hg.mozilla.org/releases/mozilla-beta",
+                    "tree": "releases/mozilla-beta"
+                },
+                "target": {
+                    "platform": "win64",
+                    "os": "win",
+                    "locale": "pt-BR",
+                    "version": "55.0b1rc5",
+                    "channel": "aurora"
+                },
+                "download": {
+                    "url": "https://archive.mozilla.org/pub/devedition/candidates/"
+                           "55.0b1-candidates/build5/win64/pt-BR/firefox-55.0b1.zip",
+                    "mimetype": "application/zip",
+                    "size": 53718907,
+                    "date": "2017-06-14T00:41:56Z"
+                },
+                "build": {
+                    "id": "20170612224034",
+                    "date": "2017-06-12T22:40:34Z",
+                    "number": 5
+                }
+            }
         }]

--- a/jobs/tests/test_utils.py
+++ b/jobs/tests/test_utils.py
@@ -86,9 +86,9 @@ RECORDS = [
 
     # Firefox DevEdition
     {
-        "id": "firefox_aurora_55-0b3_macosx_en-us",
+        "id": "devedition_aurora_55-0b3_macosx_en-us",
         "source": {
-            "product": "firefox",
+            "product": "devedition",
         },
         "target": {
             "version": "55.0b3",
@@ -629,7 +629,9 @@ RC_METADATA_FILENAMES = [
     ("mobile", "pub/mobile/candidates/56.0b1-candidates/build1/android-api-15/en-US/"
                "fennec-56.0b1.en-US.android-arm.json"),
     ("firefox", "pub/firefox/candidates/56.0b1-candidates/build4/linux-x86_64/en-US/"
-                "firefox-56.0b1.json")
+                "firefox-56.0b1.json"),
+    ("devedition", "pub/devedition/candidates/55.0b7-candidates/build1/linux-x86_64/en-US/"
+                   "firefox-55.0b7.json")
 ]
 
 


### PR DESCRIPTION
Fixes #188 

@mozbhearsum in the issue description you said we should treat devedition builds as firefox builds. But in that case how should distinguish them from firefox aurora builds?