### PR TITLE
Fix S3 event eventTime key error (fixes #253)

### DIFF
--- a/jobs/CHANGELOG.rst
+++ b/jobs/CHANGELOG.rst
@@ -6,7 +6,7 @@ This document describes changes between each past release.
 0.5.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix S3 event ``eventTime`` key error (fixes #253)
 
 
 0.4.0 (2017-09-14)

--- a/jobs/buildhub/lambda_s3_event.py
+++ b/jobs/buildhub/lambda_s3_event.py
@@ -34,16 +34,17 @@ async def main(loop, event):
     kinto_client = kinto_http.Client(server_url=server_url, auth=kinto_auth,
                                      retry=NB_RETRY_REQUEST)
 
-    # Use event time as archive publication.
-    event_time = datetime.datetime.strptime(event['eventTime'], '%Y-%m-%dT%H:%M:%S.%fZ')
-    event_time = event_time.strftime(utils.DATETIME_FORMAT)
-
     async with aiohttp.ClientSession(loop=loop) as session:
-        for record in event['Records']:
+        for event_record in event['Records']:
             records_to_create = []
 
-            key = record['s3']['object']['key']
-            filesize = record['s3']['object']['size']
+            # Use event time as archive publication.
+            event_time = datetime.datetime.strptime(event_record['eventTime'],
+                                                    '%Y-%m-%dT%H:%M:%S.%fZ')
+            event_time = event_time.strftime(utils.DATETIME_FORMAT)
+
+            key = event_record['s3']['object']['key']
+            filesize = event_record['s3']['object']['size']
             url = utils.ARCHIVE_URL + key
 
             try:

--- a/jobs/tests/data/s3-event-simple.json
+++ b/jobs/tests/data/s3-event-simple.json
@@ -1,6 +1,6 @@
 {
-    "eventTime": "2017-08-08T17:06:52.030Z",
     "Records": [{
+        "eventTime": "2017-08-08T17:06:52.030Z",
         "s3": {
             "bucket": {"name": "archive-firefox"},
             "object": {

--- a/jobs/tests/test_lamdba_s3_event.py
+++ b/jobs/tests/test_lamdba_s3_event.py
@@ -8,8 +8,8 @@ from buildhub import utils, inventory_to_records, lambda_s3_event
 
 def fake_event(key):
     return {
-        "eventTime": "2017-08-08T17:06:52.030Z",
         "Records": [{
+            "eventTime": "2017-08-08T17:06:52.030Z",
             "s3": {
                 "bucket": {"name": "abc"},
                 "object": {


### PR DESCRIPTION
fixes #253 

I have no idea how I came up with the idea that `eventTime` was on the top mapping, whereas every example out there has `eventTime` within the mapping of each record...