### PR TITLE
Fix lambda archive build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,8 @@
 .git
-lambda.zip
-.tox
+buildhub-lambda*.zip
 **/__pycache__
 *.pyc
 *.egg-info
+jobs/.cache
+jobs/.venv
+jobs/.tox

--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,9 @@ docker-test:
 	docker run -it mozilla/buildhub test
 
 lambda.zip: docker-build
-	docker rm mozilla/buildhub || true
-	docker run --name mozilla/buildhub mozilla/buildhub lambda.zip
-	docker cp mozilla/buildhub:/app/lambda.zip .
+	docker rm mozilla-buildhub || true
+	docker run --name mozilla-buildhub mozilla/buildhub lambda.zip
+	docker cp mozilla-buildhub:/tmp/lambda.zip buildhub-lambda-`git describe`.zip
 
 upload-to-s3: lambda.zip
 	$(PYTHON) bin/upload_to_s3.py

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -27,7 +27,7 @@ case $1 in
     ;;
   lambda.zip)
     cd .venv/lib/python3.6/site-packages/
-    zip -r ../../../../lambda.zip *
+    zip -r /tmp/lambda.zip *
     ;;
   initialize-kinto)
     source .venv/bin/activate


### PR DESCRIPTION
It was completely broken !

* It failed writing `lambda.zip` to `/app` (read-only)
* It failed naming the container with `/`
* It was copying hundreds of megabytes (`.venv`, `.tox`)