### PR TITLE
Skip incomplete by default

### DIFF
--- a/jobs/CHANGELOG.rst
+++ b/jobs/CHANGELOG.rst
@@ -6,6 +6,7 @@ This document describes changes between each past release.
 0.5.0 (unreleased)
 ------------------
 
+- Skip incomplete records ­- ie. without build id
 - Fix Mac OS X metadata URLs (fixes #261)
 - Fix Mac and Windows metadata URLs from installers (fixes #269)
 - Fix beta and devedition medata URLs (#269)

--- a/jobs/buildhub/inventory_to_records.py
+++ b/jobs/buildhub/inventory_to_records.py
@@ -266,7 +266,7 @@ async def fetch_release_metadata(session, record):
     raise ValueError('Missing metadata for candidate {}'.format(url))
 
 
-async def process_batch(session, batch):
+async def process_batch(session, batch, skip_incomplete):
     # Parallel fetch of metadata for each item of the batch.
     logger.info('Fetch metadata for {} releases...'.format(len(batch)))
     futures = [fetch_metadata(session, record) for record in batch]
@@ -277,11 +277,14 @@ async def process_batch(session, batch):
         try:
             check_record(result)
         except ValueError as e:
-            logger.warning(e)
+            # Keep only results where metadata was found.
+            if skip_incomplete:
+                logger.warning(e)
+                continue
         yield {'data': result}
 
 
-async def csv_to_records(loop, stdin):
+async def csv_to_records(loop, stdin, skip_incomplete=True):
     """
     :rtype: async generator of records (dict-like)
     """
@@ -368,12 +371,13 @@ async def csv_to_records(loop, stdin):
                 if len(batch) < NB_PARALLEL_REQUESTS:
                     batch.append(record)
                 else:
-                    async for result in process_batch(session, batch):
+                    async for result in process_batch(session, batch, skip_incomplete):
                         yield result
 
                     batch = []  # Go on.
 
-        async for result in process_batch(session, batch):  # Last loop iteration.
+        # Last loop iteration.
+        async for result in process_batch(session, batch, skip_incomplete):
             yield result
 
     # Save accumulated metadata for next runs.

--- a/jobs/buildhub/lambda_s3_inventory.py
+++ b/jobs/buildhub/lambda_s3_inventory.py
@@ -137,7 +137,7 @@ async def main(loop, inventory):
     async with session.create_client('s3', region_name=REGION_NAME, config=boto_config) as client:
         keys_stream = list_manifest_entries(loop, client, inventory)
         csv_stream = download_csv(loop, client, keys_stream)
-        records_stream = csv_to_records(loop, csv_stream)
+        records_stream = csv_to_records(loop, csv_stream, skip_incomplete=True)
         await to_kinto(loop, records_stream, kinto_client, skip_existing=True)
 
 

--- a/jobs/buildhub/utils.py
+++ b/jobs/buildhub/utils.py
@@ -334,6 +334,8 @@ def record_from_url(url):
 
 def check_record(record):
     """Quick sanity check on record."""
+    if 'id' not in record.get('build', {}):
+        raise ValueError("Missing build id in {}".format(record))
     channel = record['target']['channel']
     if not re.match(r"^(release|aurora|beta|esr|nightly)(-old-id)?$", channel):
         raise ValueError("Suspicious channel '{}': {}".format(channel, record))

--- a/jobs/tests/test_inventory_to_records.py
+++ b/jobs/tests/test_inventory_to_records.py
@@ -577,7 +577,17 @@ class CSVToRecords(asynctest.TestCase):
                     'version': '51.0'
                 }
             }
-        }, {
+        }]
+
+    async def test_csv_to_records_keep_incomplete(self):
+        output = inventory_to_records.csv_to_records(self.loop, self.stdin,
+                                                     skip_incomplete=False)
+        records = []
+        async for r in output:
+            records.append(r)
+
+        assert len(records) == 2
+        assert records[1] == {
             'data': {
                 'id': 'firefox_nightly_2017-06-16-03-02-07_56-0a1_win32_ach',
                 'download': {
@@ -599,4 +609,4 @@ class CSVToRecords(asynctest.TestCase):
                     'version': '56.0a1'
                 }
             }
-        }]
+        }

--- a/jobs/tests/test_inventory_to_records_functional.py
+++ b/jobs/tests/test_inventory_to_records_functional.py
@@ -44,7 +44,7 @@ class CsvToRecordsTest(asynctest.TestCase):
 
         output = sys.stdout.getvalue()
         records = [json.loads(o) for o in output.split('\n') if o]
-        assert records == [{
+        expected = [{
             'data': {
                 'id': 'firefox_nightly_2017-05-15-10-02-38_55-0a1_linux-x86_64_en-us',
                 'build': {
@@ -118,27 +118,6 @@ class CsvToRecordsTest(asynctest.TestCase):
                     'mimetype': 'application/x-bzip2',
                     'size': 60000,
                     'date': '2017-06-02T15:20:10Z'
-                }
-            }
-        }, {
-            'data': {
-                'id': 'firefox_beta_1-5b2_linux-i686_en-us',
-                'download': {
-                    'date': '2015-10-09T15:20:10Z',
-                    'mimetype': 'application/x-gzip',
-                    'size': 60000,
-                    'url': ('https://archive.mozilla.org/pub/firefox/releases/1.5b2/'
-                            'linux-i686/en-US/firefox-1.5b2.tar.gz')
-                },
-                'source': {
-                    'product': 'firefox'
-                },
-                'target': {
-                    'channel': 'beta',
-                    'locale': 'en-US',
-                    'platform': 'linux-i686',
-                    'os': 'linux',
-                    'version': '1.5b2'
                 }
             }
         }, {
@@ -282,3 +261,6 @@ class CsvToRecordsTest(asynctest.TestCase):
                 }
             }
         }]
+
+        assert [r['data']['id'] for r in records] == [r['data']['id'] for r in expected]
+        assert records == expected

--- a/jobs/tests/test_utils.py
+++ b/jobs/tests/test_utils.py
@@ -634,9 +634,15 @@ def test_build_record_id(record):
     assert record_id == record['id']
 
 
-@pytest.mark.parametrize('record', RECORDS)
+@pytest.mark.parametrize('record', [r for r in RECORDS if 'build' in r])
 def test_check_record(record):
     check_record(record)  # not raising.
+
+
+@pytest.mark.parametrize('record', [r for r in RECORDS if 'build' not in r])
+def test_check_record_raising(record):
+    with pytest.raises(ValueError):
+        check_record(record)
 
 
 RELEASE_METADATA_FILENAMES = [


### PR DESCRIPTION
The more I think of it, the more I think we should get rid of the records without ids.
On stage we almost have like a million records, this is nuts.

This PR skips the records without build id.
