### PR TITLE
Keep trace but skip build urls that have unsupported formats

### DIFF
--- a/jobs/CHANGELOG.rst
+++ b/jobs/CHANGELOG.rst
@@ -8,6 +8,7 @@ This document describes changes between each past release.
 ------------------
 
 - Add ability to configure cache folder via environment variable ``CACHE_FOLDER``
+- Keep trace but skip build urls that have unsupported formats
 
 0.6.0 (2017-10-10)
 ------------------

--- a/jobs/buildhub/inventory_to_records.py
+++ b/jobs/buildhub/inventory_to_records.py
@@ -367,8 +367,11 @@ async def csv_to_records(loop, stdin, skip_incomplete=True):
 
                 if not is_build_url(product, url):
                     continue
-
-                record = record_from_url(url)
+                try:
+                    record = record_from_url(url)
+                except Exception as e:
+                    logger.exception(e)
+                    continue
 
                 # Complete with info that can't be obtained from the URL.
                 filesize = int(float(entry['Size']))  # e.g. 2E+10

--- a/jobs/tests/test_inventory_to_records.py
+++ b/jobs/tests/test_inventory_to_records.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+from unittest import mock
 
 import aiohttp
 import asynctest
@@ -634,3 +635,12 @@ class CSVToRecords(asynctest.TestCase):
                 }
             }
         }
+
+    @mock.patch('buildhub.utils.guess_mimetype',
+                side_effect=[{}, ValueError, {}])
+    async def test_csv_to_records_continues_on_error(self, mock):
+        output = inventory_to_records.csv_to_records(self.loop, stdin)
+        records = []
+        async for r in output:
+            records.append(r)
+        assert records == [{}, {}]

--- a/jobs/tests/test_inventory_to_records.py
+++ b/jobs/tests/test_inventory_to_records.py
@@ -636,11 +636,13 @@ class CSVToRecords(asynctest.TestCase):
             }
         }
 
-    @mock.patch('buildhub.utils.guess_mimetype',
-                side_effect=[{}, ValueError, {}])
-    async def test_csv_to_records_continues_on_error(self, mock):
-        output = inventory_to_records.csv_to_records(self.loop, stdin)
-        records = []
-        async for r in output:
-            records.append(r)
-        assert records == [{}, {}]
+    async def test_csv_to_records_continues_on_error(self):
+        with mock.patch('buildhub.utils.guess_mimetype',
+                        side_effect=(ValueError, 'application/zip')):
+            output = inventory_to_records.csv_to_records(self.loop, self.stdin,
+                                                         skip_incomplete=False)
+            records = []
+            async for r in output:
+                records.append(r)
+
+        assert len(records) == 1  # Instead of 2 like the test above.


### PR DESCRIPTION
@Natim I can't figure out why the `mock` has no effect...