### PR TITLE
Fix missing metadata for nightly archives (Fixes #296)

### DIFF
--- a/jobs/buildhub/inventory_to_records.py
+++ b/jobs/buildhub/inventory_to_records.py
@@ -140,7 +140,8 @@ async def fetch_nightly_metadata(session, record):
         except aiohttp.ClientError as e:
             pass
 
-        logger.warning("Could not fetch metadata for '%s' from '%s'" % (record['id'], metadata_url))
+        logger.warning("Could not fetch metadata for '%s' from '%s'" % (record['id'],
+                                                                        metadata_url))
         _nightly_metadata[url] = None  # Don't try it anymore.
         return None
 
@@ -176,7 +177,8 @@ async def fetch_release_candidate_metadata(session, record):
     except aiohttp.ClientError as e:
         # Old RC like https://archive.mozilla.org/pub/firefox/releases/1.0rc1/
         # don't have metadata.
-        logger.warning("Could not fetch metadata for '%s' from '%s'" % (record['id'], metadata_url))
+        logger.warning("Could not fetch metadata for '%s' from '%s'" % (record['id'],
+                                                                        metadata_url))
         _rc_metadata[rc_url] = None  # Don't try it anymore.
         return None
 

--- a/jobs/buildhub/inventory_to_records.py
+++ b/jobs/buildhub/inventory_to_records.py
@@ -140,7 +140,7 @@ async def fetch_nightly_metadata(session, record):
         except aiohttp.ClientError as e:
             pass
 
-        logger.error("Could not fetch metadata for '%s' from '%s'" % (record['id'], metadata_url))
+        logger.warning("Could not fetch metadata for '%s' from '%s'" % (record['id'], metadata_url))
         _nightly_metadata[url] = None  # Don't try it anymore.
         return None
 
@@ -176,7 +176,7 @@ async def fetch_release_candidate_metadata(session, record):
     except aiohttp.ClientError as e:
         # Old RC like https://archive.mozilla.org/pub/firefox/releases/1.0rc1/
         # don't have metadata.
-        logger.error("Could not fetch metadata for '%s' from '%s'" % (record['id'], metadata_url))
+        logger.warning("Could not fetch metadata for '%s' from '%s'" % (record['id'], metadata_url))
         _rc_metadata[rc_url] = None  # Don't try it anymore.
         return None
 

--- a/jobs/buildhub/lambda_s3_event.py
+++ b/jobs/buildhub/lambda_s3_event.py
@@ -195,7 +195,7 @@ def lambda_handler(event, context):
 
     try:
         loop.run_until_complete(main(loop, event))
-    except:
+    except Exception:
         logger.exception('Aborted.')
         raise
     finally:

--- a/jobs/buildhub/lambda_s3_inventory.py
+++ b/jobs/buildhub/lambda_s3_inventory.py
@@ -155,7 +155,7 @@ def lambda_handler(event=None, context=None):
     futures = [main(loop, inventory) for inventory in ('firefox', 'archive')]
     try:
         loop.run_until_complete(asyncio.gather(*futures))
-    except:
+    except Exception:
         logger.exception('Aborted.')
         raise
     finally:

--- a/jobs/tests/test_lamdba_s3_event.py
+++ b/jobs/tests/test_lamdba_s3_event.py
@@ -53,11 +53,11 @@ class BaseTest(asynctest.TestCase):
         self.addCleanup(patch.stop)
         self.mock_create_record = patch.start()
 
-        mocked = aioresponses()
-        mocked.start()
+        self.mockresponses = aioresponses()
+        self.mockresponses.start()
         for url, payload in self.remote_content.items():
-            mocked.get(utils.ARCHIVE_URL + url, payload=payload)
-        self.addCleanup(mocked.stop)
+            self.mockresponses.get(utils.ARCHIVE_URL + url, payload=payload)
+        self.addCleanup(self.mockresponses.stop)
 
     def tearDown(self):
         inventory_to_records._candidates_build_folder.clear()
@@ -484,6 +484,31 @@ class FromRCMetadataFirefox(BaseTest):
                 },
             },
             if_not_exists=True)
+
+
+class FromNightlyArchiveFirefox(BaseTest):
+    remote_content = {
+        'pub/firefox/candidates/': {
+            'prefixes': [
+                'archived/'
+            ], 'files': []
+        },
+    }
+
+    def setUp(self):
+        super().setUp()
+        self.mockresponses.get(utils.ARCHIVE_URL +
+                               "pub/firefox/nightly/2017/08/2017-08-05-10-03-34-mozilla-central/"
+                               "firefox-57.0a1.en-US.linux-x86_64.json",
+                               status=404, headers={"Content-Type": "text/html"},
+                               body="<html></html>")
+
+    async def test_from_nightly_archive_linux_metadata_missing(self):
+        event = fake_event('pub/firefox/nightly/2017/08/2017-08-05-10-03-34-mozilla-central-l10n/'
+                           'firefox-57.0a1.ru.linux-x86_64.tar.bz2')
+        await lambda_s3_event.main(self.loop, event)
+
+        assert not self.mock_create_record.called
 
 
 class FromNightlyMetadataFirefox(BaseTest):

--- a/jobs/tests/test_lamdba_s3_event.py
+++ b/jobs/tests/test_lamdba_s3_event.py
@@ -1829,3 +1829,29 @@ class FromNightlyMetadataAndroid(BaseTest):
                 },
             },
             if_not_exists=True)
+
+
+class FromNightlyArchiveFennec(BaseTest):
+    remote_content = {
+        'pub/mobile/candidates/': {
+            'prefixes': [
+                'archived/'
+            ], 'files': []
+        },
+    }
+
+    def setUp(self):
+        super().setUp()
+        self.mockresponses.get(utils.ARCHIVE_URL +
+                               "pub/mobile/nightly/2017/10/2017-10-29-10-22-14-"
+                               "mozilla-central-android-api-16/"
+                               "fennec-58.0a1.multi.android-arm.json",
+                               status=404, headers={"Content-Type": "text/html"},
+                               body="<html></html>")
+
+    async def test_from_nightly_archive_linux_metadata_missing(self):
+        event = fake_event('pub/mobile/nightly/2017/10/2017-10-29-10-22-14-mozilla-'
+                           'central-android-api-16-l10n/fennec-58.0a1.ka.android-arm.apk')
+        await lambda_s3_event.main(self.loop, event)
+
+        assert not self.mock_create_record.called

--- a/jobs/tests/test_to_kinto.py
+++ b/jobs/tests/test_to_kinto.py
@@ -13,7 +13,7 @@ class CacheValueTest(unittest.TestCase):
     def tearDown(self):
         try:
             os.path.remove(self.cache_file)
-        except:
+        except Exception:
             pass
 
     def test_records_are_not_duplicated(self):


### PR DESCRIPTION
The problem was due to the fact that our tests didn't return a 404 HTML response but a connection refused when the URL was not mocked by `aiohttpresponses`

Fixes #296 