### PR TITLE
Prevent test_packages metadata from being recognized as release metadata (fixes #295)

### DIFF
--- a/jobs/CHANGELOG.rst
+++ b/jobs/CHANGELOG.rst
@@ -6,7 +6,7 @@ This document describes changes between each past release.
 1.0.0 (2017-10-12)
 ------------------
 
-- No changes yet.
+- Prevent test_packages metadata from being recognized as release metadata (fixes #295)
 
 
 1.0.0 (2017-10-12)

--- a/jobs/buildhub/utils.py
+++ b/jobs/buildhub/utils.py
@@ -191,6 +191,10 @@ def is_nightly_build_metadata(product, url):
         return False
     if product == 'mobile':
         product = 'fennec'
+    # Exlude alias folder, and other metadata.
+    re_exclude = re.compile('.+latest-mozilla-central|test_packages')
+    if re_exclude.match(url):
+        return False
     # Note: devedition has no nightly.
     re_metadata = re.compile('.+/{}-(.*)\.(.*)\.(.*)\.json$'.format(product))
     return bool(re_metadata.match(url))

--- a/jobs/tests/test_utils.py
+++ b/jobs/tests/test_utils.py
@@ -735,7 +735,9 @@ WRONG_NIGHTLY_METADATA_FILENAMES = [
     ('mobile', 'pub/mobile/nightly/2017/08/2017-08-01-15-03-46-date-android-api-15/'
                'fennec-56.0a1.multi.android-arm.json'),
     ('firefox', 'pub/firefox/candidates/56.0b1-candidates/build4/linux-x86_64/en-US/'
-                'firefox-56.0b1.json')
+                'firefox-56.0b1.json'),
+    ('firefox', 'pub/firefox/nightly/latest-mozilla-central/firefox-58.0a1.en-US.'
+                'win64.test_packages.json')
 ]
 
 


### PR DESCRIPTION
Fixes #295