### PR TITLE
Use requirements.txt versions when building the container (fixes #299)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,9 @@ buildhub-lambda*.zip
 **/__pycache__
 *.pyc
 *.egg-info
+.venv
+*.zip
+
 jobs/.cache
 jobs/.venv
 jobs/.tox

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /app
 
 RUN \
     make virtualenv && \
-    .venv/bin/pip install jobs/ && \
+    .venv/bin/pip install --constraint jobs/requirements.txt jobs/ && \
     .venv/bin/pip freeze | grep -v -- 'buildhub' > dependencies.txt
 
 RUN groupadd -g 10001 app && \

--- a/jobs/CHANGELOG.rst
+++ b/jobs/CHANGELOG.rst
@@ -6,7 +6,7 @@ This document describes changes between each past release.
 1.0.0 (2017-10-12)
 ------------------
 
-- No changes yet.
+- Use ``requirements.txt`` versions when building the container (fixes #299)
 
 
 1.0.0 (2017-10-12)


### PR DESCRIPTION
fixes #299


```
 ---> Running in 634387a386d4
virtualenv --python=python3.6 .venv --python=python3.6
Using base prefix '/usr/local'
New python executable in /app/.venv/bin/python3.6
Also creating executable in /app/.venv/bin/python
Installing setuptools, pip, wheel...done.
Running virtualenv with interpreter /usr/local/bin/python3.6
Processing ./jobs
Collecting aiobotocore==0.4.5 (from -c jobs/requirements.txt (line 1))
  Downloading aiobotocore-0.4.5-py3-none-any.whl
Collecting aiohttp==2.3.0 (from -c jobs/requirements.txt (line 2))
  Downloading aiohttp-2.3.0-cp36-cp36m-manylinux1_x86_64.whl (661kB)
Collecting async-timeout==2.0.0 (from -c jobs/requirements.txt (line 3))
  Downloading async_timeout-2.0.0-py3-none-any.whl
Collecting backoff==1.4.3 (from -c jobs/requirements.txt (line 4))
  Downloading backoff-1.4.3.tar.gz
Collecting botocore==1.7.5 (from -c jobs/requirements.txt (line 5))
  Downloading botocore-1.7.5-py2.py3-none-any.whl (3.6MB)
Collecting chardet==3.0.4 (from -c jobs/requirements.txt (line 7))
  Downloading chardet-3.0.4-py2.py3-none-any.whl (133kB)
Collecting docutils==0.14 (from -c jobs/requirements.txt (line 8))
  Downloading docutils-0.14-py3-none-any.whl (543kB)
Collecting jmespath==0.9.3 (from -c jobs/requirements.txt (line 10))
  Downloading jmespath-0.9.3-py2.py3-none-any.whl
Collecting kinto-http==9.0.1 (from -c jobs/requirements.txt (line 11))
  Downloading kinto_http-9.0.1-py2.py3-none-any.whl (40kB)
Collecting kinto-wizard==2.3.0 (from -c jobs/requirements.txt (line 12))
  Downloading kinto_wizard-2.3.0-py2.py3-none-any.whl
Collecting multidict==3.3.2 (from -c jobs/requirements.txt (line 13))
  Downloading multidict-3.3.2-cp36-cp36m-manylinux1_x86_64.whl (450kB)
Collecting packaging==16.8 (from -c jobs/requirements.txt (line 14))
  Downloading packaging-16.8-py2.py3-none-any.whl
Collecting pyparsing==2.2.0 (from -c jobs/requirements.txt (line 15))
  Downloading pyparsing-2.2.0-py2.py3-none-any.whl (56kB)
Collecting python-dateutil==2.6.1 (from -c jobs/requirements.txt (line 16))
  Downloading python_dateutil-2.6.1-py2.py3-none-any.whl (194kB)
Collecting raven==6.3.0 (from -c jobs/requirements.txt (line 17))
  Downloading raven-6.3.0-py2.py3-none-any.whl (280kB)
Collecting requests==2.18.4 (from -c jobs/requirements.txt (line 18))
  Downloading requests-2.18.4-py2.py3-none-any.whl (88kB)
Collecting ruamel.yaml==0.15.34 (from -c jobs/requirements.txt (line 19))
  Downloading ruamel.yaml-0.15.34-cp36-cp36m-manylinux1_x86_64.whl (557kB)
Collecting six==1.11.0 (from -c jobs/requirements.txt (line 20))
  Downloading six-1.11.0-py2.py3-none-any.whl
Collecting Unidecode==0.4.21 (from -c jobs/requirements.txt (line 21))
  Downloading Unidecode-0.04.21-py2.py3-none-any.whl (228kB)
Collecting urllib3==1.22 (from -c jobs/requirements.txt (line 22))
  Downloading urllib3-1.22-py2.py3-none-any.whl (132kB)
Collecting wrapt==1.10.11 (from -c jobs/requirements.txt (line 23))
  Downloading wrapt-1.10.11.tar.gz
Collecting yarl==0.13.0 (from -c jobs/requirements.txt (line 24))
  Downloading yarl-0.13.0-cp36-cp36m-manylinux1_x86_64.whl (177kB)
Collecting idna==2.6 (from -c jobs/requirements.txt (line 9))
  Downloading idna-2.6-py2.py3-none-any.whl (56kB)
Collecting certifi==2017.7.27.1 (from -c jobs/requirements.txt (line 6))
  Downloading certifi-2017.7.27.1-py2.py3-none-any.whl (349kB)
Building wheels for collected packages: backoff, wrapt
  Running setup.py bdist_wheel for backoff: started
  Running setup.py bdist_wheel for backoff: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/66/bb/31/ff24081be4b0e70839238647726c8888ed6fca005a2efca8ce
  Running setup.py bdist_wheel for wrapt: started
  Running setup.py bdist_wheel for wrapt: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/56/e1/0f/f7ccf1ed8ceaabccc2a93ce0481f73e589814cbbc439291345
Successfully built backoff wrapt
Installing collected packages: wrapt, multidict, jmespath, six, python-dateutil, docutils, botocore, pyparsing, packaging, async-timeout, chardet, yarl, aiohttp, aiobotocore, backoff, certifi, idna, Unidecode, urllib3, requests, kinto-http, ruamel.yaml, kinto-wizard, raven, buildhub
  Running setup.py install for buildhub: started
    Running setup.py install for buildhub: finished with status 'done'
Successfully installed Unidecode-0.4.21 aiobotocore-0.4.5 aiohttp-2.3.0 async-timeout-2.0.0 backoff-1.4.3 botocore-1.7.5 buildhub-1.1.0.dev0 certifi-2017.7.27.1 chardet-3.0.4 docutils-0.14 idna-2.6 jmespath-0.9.3 kinto-http-9.0.1 kinto-wizard-2.3.0 multidict-3.3.2 packaging-16.8 pyparsing-2.2.0 python-dateutil-2.6.1 raven-6.3.0 requests-2.18.4 ruamel.yaml-0.15.34 six-1.11.0 urllib3-1.22 wrapt-1.10.11 yarl-0.13.0
 ---> f0f577472aaa
Removing intermediate container 634387a386d4
Step 7/12 : RUN groupadd -g 10001 app &&     useradd -M -u 10001 -g 10001 -G app -d /app -s /sbin/nologin app
 ---> Running in ecb39b68930a
 ---> c50e32562492
Removing intermediate container ecb39b68930a
Step 8/12 : ENV CACHE_FOLDER /app/cache
 ---> Running in 37abcff249ce
 ---> e8f5cb1b3acf
Removing intermediate container 37abcff249ce
Step 9/12 : RUN mkdir $CACHE_FOLDER &&     chown app $CACHE_FOLDER &&     chmod u+w $CACHE_FOLDER
 ---> Running in 5b55cd240768
 ---> 49128eaca1e2
Removing intermediate container 5b55cd240768
Step 10/12 : ENTRYPOINT /bin/bash /app/bin/run.sh
 ---> Running in 3051bfc9ebeb
 ---> a93eb370c91b
Removing intermediate container 3051bfc9ebeb
Step 11/12 : USER app
 ---> Running in 6069877f041d
 ---> d0c9f81ae6f2
Removing intermediate container 6069877f041d
Step 12/12 : CMD help
 ---> Running in a7f134792f59
 ---> d832e4d3ce0c
Removing intermediate container a7f134792f59
Successfully built d832e4d3ce0c


```