### PR TITLE
Fix test_packages regexp to avoid confusion with build metadata (fixes #295, #309)

### DIFF
--- a/jobs/CHANGELOG.rst
+++ b/jobs/CHANGELOG.rst
@@ -6,7 +6,7 @@ This document describes changes between each past release.
 1.2.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix test_packages regexp to avoid confusion with build metadata (fixes #295, #309)
 
 1.1.0 (2017-11-03)
 ------------------

--- a/jobs/buildhub/utils.py
+++ b/jobs/buildhub/utils.py
@@ -192,7 +192,7 @@ def is_nightly_build_metadata(product, url):
     if product == 'mobile':
         product = 'fennec'
     # Exlude alias folder, and other metadata.
-    re_exclude = re.compile('.+latest-mozilla-central|test_packages')
+    re_exclude = re.compile('.+(latest-mozilla-central|test_packages)')
     if re_exclude.match(url):
         return False
     # Note: devedition has no nightly.

--- a/jobs/tests/test_utils.py
+++ b/jobs/tests/test_utils.py
@@ -737,7 +737,9 @@ WRONG_NIGHTLY_METADATA_FILENAMES = [
     ('firefox', 'pub/firefox/candidates/56.0b1-candidates/build4/linux-x86_64/en-US/'
                 'firefox-56.0b1.json'),
     ('firefox', 'pub/firefox/nightly/latest-mozilla-central/firefox-58.0a1.en-US.'
-                'win64.test_packages.json')
+                'win64.test_packages.json'),
+    ('firefox', 'pub/firefox/nightly/2017/11/2017-11-29-11-10-30-mozilla-central/'
+                'firefox-59.0a1.en-US.win32.test_packages.json')
 ]
 
 


### PR DESCRIPTION
fixes #295, #309