### PR TITLE
Fix exclusion of thunderbird nightly releases (fixes #312)

### DIFF
--- a/jobs/CHANGELOG.rst
+++ b/jobs/CHANGELOG.rst
@@ -3,6 +3,11 @@ Changelog
 
 This document describes changes between each past release.
 
+1.1.2 (unreleased)
+------------------
+
+- Fix exclusion of thunderbird nightly releases (fixes #312)
+
 1.1.1 (2017-11-30)
 ------------------
 

--- a/jobs/buildhub/utils.py
+++ b/jobs/buildhub/utils.py
@@ -149,7 +149,7 @@ def is_build_url(product, url):
           fennec-57.0a1.hi-IN.android-arm.apk
     - firefox/nightly/2017/08/2017-08-25-10-01-26-mozilla-central-l10n/Firefox Installer.fr.exe
     """
-    if 'nightly' in url and 'mozilla-central' not in url:
+    if 'nightly' in url and 'mozilla-central' not in url and 'comm-central' not in url:
         return False
 
     re_exclude = re.compile('.+(tinderbox|try-builds|partner-repacks|latest|contrib|/0\.|'

--- a/jobs/tests/test_utils.py
+++ b/jobs/tests/test_utils.py
@@ -798,6 +798,10 @@ RELEASE_FILENAMES = [
                'android-api-15-l10n/fennec-57.0a1.hi-IN.android-arm.apk'),
     ('firefox', 'pub/firefox/nightly/2017/08/2017-08-25-10-01-26-mozilla-central-'
                 'l10n/firefox-57.0a1.an.win32.installer.exe'),
+    ('thunderbird', 'pub/thunderbird/nightly/2017/12/2017-12-13-04-12-17-comm-central/'
+                    'thunderbird-59.0a1.en-US.mac.dmg'),
+    ('thunderbird', 'pub/thunderbird/nightly/2017/12/2017-12-13-04-12-17-comm-central/'
+                    'thunderbird-59.0a1.en-US.linux-x86_64.tar.bz2'),
 ]
 
 
@@ -831,6 +835,8 @@ WRONG_RELEASE_FILENAMES = [
     ('firefox', '/pub/firefox/nightly/2017/08/2017-08-25-10-01-26-mozilla-central-l10n/'
                 'Firefox Installer.fr.exe'),
     ('firefox', '/pub/firefox/releases/1.0rc1/Firefox%20Setup %281.0rc1, ca-AD%29.exe'),
+    ('thunderbird', 'pub/thunderbird/nightly/2017/12/2017-12-11-03-02-03-comm-esr52/'
+                    'thunderbird-52.0.en-US.win32.zip'),
 ]
 
 


### PR DESCRIPTION
Fixes #312 

I still excluded the nightly ESR releases. Is that OK @calixteman?