### PR TITLE
Prevent mozinfo JSON files to be mistaken as Nightly metadata (fixes #315)

### DIFF
--- a/jobs/CHANGELOG.rst
+++ b/jobs/CHANGELOG.rst
@@ -7,6 +7,7 @@ This document describes changes between each past release.
 ------------------
 
 - Fix exclusion of thunderbird nightly releases (fixes #312)
+- Prevent mozinfo JSON files to be mistaken as Nightly metadata (fixes #315)
 
 1.1.1 (2017-11-30)
 ------------------

--- a/jobs/buildhub/utils.py
+++ b/jobs/buildhub/utils.py
@@ -192,7 +192,7 @@ def is_nightly_build_metadata(product, url):
     if product == 'mobile':
         product = 'fennec'
     # Exlude alias folder, and other metadata.
-    re_exclude = re.compile('.+(latest-mozilla-central|test_packages)')
+    re_exclude = re.compile('.+(latest-mozilla-central|test_packages|mozinfo)')
     if re_exclude.match(url):
         return False
     # Note: devedition has no nightly.

--- a/jobs/tests/test_utils.py
+++ b/jobs/tests/test_utils.py
@@ -739,7 +739,9 @@ WRONG_NIGHTLY_METADATA_FILENAMES = [
     ('firefox', 'pub/firefox/nightly/latest-mozilla-central/firefox-58.0a1.en-US.'
                 'win64.test_packages.json'),
     ('firefox', 'pub/firefox/nightly/2017/11/2017-11-29-11-10-30-mozilla-central/'
-                'firefox-59.0a1.en-US.win32.test_packages.json')
+                'firefox-59.0a1.en-US.win32.test_packages.json'),
+    ('firefox', 'pub/firefox/nightly/2017/12/2017-12-19-10-02-03-mozilla-central/'
+                'firefox-59.0a1.en-US.win32.mozinfo.json'),
 ]
 
 


### PR DESCRIPTION
Fixes #315