### PR TITLE
Retry fetch JSON when status is not 200 (ref #327)

### DIFF
--- a/jobs/buildhub/inventory_to_records.py
+++ b/jobs/buildhub/inventory_to_records.py
@@ -45,7 +45,7 @@ async def read_csv(input_generator):
 
 
 @backoff.on_exception(backoff.expo,
-                      asyncio.TimeoutError,
+                      (aiohttp.ClientResponseError, asyncio.TimeoutError),
                       max_tries=NB_RETRY_REQUEST)
 async def fetch_json(session, url, timeout=TIMEOUT_SECONDS):
     headers = {
@@ -57,6 +57,7 @@ async def fetch_json(session, url, timeout=TIMEOUT_SECONDS):
         with async_timeout.timeout(timeout):
             logger.debug("GET '{}'".format(url))
             async with session.get(url, headers=headers, timeout=None) as response:
+                response.raise_for_status()
                 try:
                     return await response.json()
                 except aiohttp.ClientResponseError as e:

--- a/jobs/dev-requirements.txt
+++ b/jobs/dev-requirements.txt
@@ -1,7 +1,7 @@
 aioresponses
 asynctest
 flake8
-pytest
+pytest==3.3.2
 pytest-cache
 pytest-cover
 pytest-sugar


### PR DESCRIPTION
ref #327 

We've seen a lot of `text/html` errors lately
![screenshot from 2018-02-01 11-36-19](https://user-images.githubusercontent.com/546692/35674217-31617be4-0744-11e8-9abc-8ae5a32e989b.png)

I suspect them to be 404 because of some kind of latency/race condition while reaching S3 through bucketlister (https://github.com/mozilla-services/product-delivery-tools/tree/master/bucketlister)

This PR will retry requests when receiving non `200 OK` responses. It does no harm and could help but it might also be flogging a dead horse...